### PR TITLE
Add basic API tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Plant Tracker
+
+This is a simple PHP-based application for tracking plants.
+
+## Running Tests
+
+The project includes a minimal PHPUnit test suite for the API endpoints. To run the tests:
+
+1. Install PHPUnit if it is not already available. On Ubuntu you can run:
+   ```bash
+   sudo apt-get update && sudo apt-get install -y phpunit
+   ```
+2. Execute PHPUnit from the repository root:
+   ```bash
+   phpunit --configuration phpunit.xml
+   ```
+
+The tests use a stub database connection and do not require a real database.

--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -1,11 +1,19 @@
 <?php
-include '../db.php';
+$dbConfig = getenv('DB_CONFIG');
+if ($dbConfig && file_exists($dbConfig)) {
+    include $dbConfig;
+} else {
+    include '../db.php';
+}
 
 // Basic validation
 if (!isset($_POST['name']) || trim($_POST['name']) === '') {
-    http_response_code(400);
+    @http_response_code(400);
     echo json_encode(['error' => 'Plant name is required']);
-    exit;
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
 }
 
 // Clean and trim inputs

--- a/api/delete_plant.php
+++ b/api/delete_plant.php
@@ -1,5 +1,10 @@
 <?php
-include('../db.php');
+$dbConfig = getenv('DB_CONFIG');
+if ($dbConfig && file_exists($dbConfig)) {
+    include $dbConfig;
+} else {
+    include('../db.php');
+}
 
 $id = $_POST['id'] ?? null;
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+    <testsuites>
+        <testsuite name="PlantTracker Test Suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -1,0 +1,35 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ApiTest extends TestCase
+{
+    private $dbConfig;
+    protected function setUp(): void
+    {
+        $this->dbConfig = __DIR__ . '/db_stub.php';
+        putenv('DB_CONFIG=' . $this->dbConfig);
+        putenv('TESTING=1');
+    }
+
+    public function testAddPlantMissingName()
+    {
+        $_POST = [];
+        ob_start();
+        include __DIR__ . '/../api/add_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertArrayHasKey('error', $data);
+    }
+
+    public function testDeletePlantMissingId()
+    {
+        $_POST = [];
+        ob_start();
+        include __DIR__ . '/../api/delete_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertFalse($data['success']);
+        $this->assertArrayHasKey('error', $data);
+    }
+}
+?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+// Bootstrap for tests

--- a/tests/db_stub.php
+++ b/tests/db_stub.php
@@ -1,0 +1,20 @@
+<?php
+if (!class_exists('MockStmt')) {
+    class MockStmt {
+        public function bind_param(...$args) {}
+        public function execute() { return true; }
+        public function close() {}
+    }
+}
+
+if (!class_exists('MockMysqli')) {
+    class MockMysqli {
+        public $connect_error = '';
+        public function prepare($query) {
+            return new MockStmt();
+        }
+    }
+}
+
+$conn = new MockMysqli();
+?>


### PR DESCRIPTION
## Summary
- add PHPUnit config and integration tests
- stub DB connection for testing
- allow API scripts to use a custom DB config and skip exit when testing
- document running tests in README

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6859e6e4b3a883249099676faa3caf96