### PR TITLE
Use configurable DB for all endpoints

### DIFF
--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -1,7 +1,12 @@
 <?php
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
-include '../db.php';
+$dbConfig = getenv('DB_CONFIG');
+if ($dbConfig && file_exists($dbConfig)) {
+    include $dbConfig;
+} else {
+    include '../db.php';
+}
 
 header('Content-Type: application/json');
 

--- a/api/mark_fertilized.php
+++ b/api/mark_fertilized.php
@@ -1,7 +1,12 @@
 <?php
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
-include '../db.php';
+$dbConfig = getenv('DB_CONFIG');
+if ($dbConfig && file_exists($dbConfig)) {
+    include $dbConfig;
+} else {
+    include '../db.php';
+}
 
 $id = intval($_POST['id']);
 $snooze = isset($_POST['snooze_days']) ? intval($_POST['snooze_days']) : 0;

--- a/api/mark_watered.php
+++ b/api/mark_watered.php
@@ -1,7 +1,12 @@
 <?php
 ini_set('display_errors', 1);
 error_reporting(E_ALL);
-include '../db.php';
+$dbConfig = getenv('DB_CONFIG');
+if ($dbConfig && file_exists($dbConfig)) {
+    include $dbConfig;
+} else {
+    include '../db.php';
+}
 
 $id = intval($_POST['id']);
 $snooze = isset($_POST['snooze_days']) ? intval($_POST['snooze_days']) : 0;

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -1,5 +1,10 @@
 <?php
-include '../db.php';
+$dbConfig = getenv('DB_CONFIG');
+if ($dbConfig && file_exists($dbConfig)) {
+    include $dbConfig;
+} else {
+    include '../db.php';
+}
 
 // Collect and sanitize
 $id                      = intval($_POST['id'] ?? 0);


### PR DESCRIPTION
## Summary
- look for DB config in `DB_CONFIG` environment variable across api scripts
- fallback to local `db.php` when config isn't specified

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6859e945d6e88324bbd865c1b998def0