### PR TITLE
Use env vars and document DB credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ node_modules/
 # IDE/editor directories
 .idea/
 .vscode/
+
+# PHPUnit result cache
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ Set the following environment variables so `db.php` can establish the database c
 - `DB_PASS` - user password
 - `DB_NAME` - name of the database
 
+`db.php` reads these values using `getenv`. Ensure the variables are available in
+your environment (or defined in a `.env` file loaded by your web server) before
+running the application so credentials are not stored in the codebase.
+


### PR DESCRIPTION
## Summary
- document DB env vars in README
- ignore phpunit cache file

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6859e947a08083249e2518fa14822af2