### PR TITLE
Switch plant list to table layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -173,48 +173,62 @@ async function loadPlants() {
     header.textContent = room || 'No Room';
     list.appendChild(header);
 
+    const table = document.createElement('table');
+    table.classList.add('plant-table');
+    const thead = document.createElement('thead');
+    thead.innerHTML = '<tr><th>Name</th><th>Species</th><th>Frequencies</th><th>Actions</th></tr>';
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+
     roomPlants.forEach(plant => {
-      const item = document.createElement('div');
-      item.classList.add('plant-item');
+      const row = document.createElement('tr');
       if (plant.id===window.lastUpdatedPlantId) {
-        item.classList.add('just-updated');
-        setTimeout(()=>item.classList.remove('just-updated'),2000);
+        row.classList.add('just-updated');
+        setTimeout(()=>row.classList.remove('just-updated'),2000);
       }
 
       // inline editable Name
+      const nameTd = document.createElement('td');
       const nameInput = document.createElement('input');
       nameInput.value = plant.name;
       nameInput.onblur = () => updatePlantInline(plant,'name',nameInput.value);
-      item.appendChild(nameInput);
+      nameTd.appendChild(nameInput);
+      row.appendChild(nameTd);
 
       // inline editable Species
+      const specTd = document.createElement('td');
       const specInput = document.createElement('input');
       specInput.value = plant.species;
       specInput.onblur = () => updatePlantInline(plant,'species',specInput.value);
-      item.appendChild(specInput);
+      specTd.appendChild(specInput);
+      row.appendChild(specTd);
 
-      // static frequencies and room inline
-      const info = document.createElement('span');
-      info.textContent = `– water every ${plant.watering_frequency} days` +
-                         (plant.fertilizing_frequency?`, fertilize every ${plant.fertilizing_frequency} days`:``);
-      item.appendChild(info);
-
+      // static frequencies and editable room
+      const freqTd = document.createElement('td');
+      freqTd.textContent = `water every ${plant.watering_frequency} days` +
+                           (plant.fertilizing_frequency?`, fertilize every ${plant.fertilizing_frequency} days`:``);
       const roomInput = document.createElement('input');
       roomInput.value = plant.room;
       roomInput.onblur = () => updatePlantInline(plant,'room',roomInput.value);
-      item.appendChild(roomInput);
+      freqTd.appendChild(document.createElement('br'));
+      freqTd.appendChild(roomInput);
+      row.appendChild(freqTd);
 
       // due badges & actions (omitted for brevity, same as before)
       // ...
 
+      const actionsTd = document.createElement('td');
       // delete with undo
       const delBtn = document.createElement('button');
       delBtn.textContent = '🗑️';
       delBtn.onclick = () => showUndoBanner(plant);
-      item.appendChild(delBtn);
+      actionsTd.appendChild(delBtn);
+      row.appendChild(actionsTd);
 
-      list.appendChild(item);
+      tbody.appendChild(row);
     });
+    table.appendChild(tbody);
+    list.appendChild(table);
   });
 
   // refresh room filter

--- a/style.css
+++ b/style.css
@@ -78,3 +78,15 @@ input, button {
   margin-bottom: 1rem;
   font-weight: bold;
 }
+
+/* table layout for plant listings */
+.plant-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+.plant-table th,
+.plant-table td {
+  border: 1px solid #ddd;
+  padding: 8px;
+}


### PR DESCRIPTION
## Summary
- use a `<table>` when rendering plants so rows line up cleanly
- add new CSS for `.plant-table`

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6859ed9f6ef48324be129aa5f112f274