### PR TITLE
Improve feedback with toast notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,8 @@
   Plant deleted. <button id="undo-btn">Undo</button>
 </div>
 
+<div id="toast" class="toast"></div>
+
     <div id="plant-list"></div>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,18 @@ let editingPlantId = null;
 let lastDeletedPlant = null;
 let deleteTimer = null;
 
+function showToast(msg, isError = false) {
+  const toast = document.getElementById('toast');
+  if (!toast) return;
+  toast.textContent = msg;
+  toast.classList.toggle('error', isError);
+  toast.classList.add('show');
+  clearTimeout(toast.hideTimeout);
+  toast.hideTimeout = setTimeout(() => {
+    toast.classList.remove('show');
+  }, 3000);
+}
+
 // --- validation, date math, due-date helpers ---
 function validateForm(form) {
   let valid = true;
@@ -53,7 +65,7 @@ async function markAction(id, type, days = 0) {
     loadPlants();
   } catch (err) {
     console.error('Failed to mark action:', err);
-    alert('Failed to update plant. Please try again.');
+    showToast('Failed to update plant. Please try again.', true);
   }
 }
 
@@ -95,7 +107,7 @@ async function updatePlantInline(plant, field, newValue) {
     body: data
   });
   if (!resp.ok) {
-    alert('Failed to save change');
+    showToast('Failed to save change', true);
   } else {
     loadPlants();
   }
@@ -251,10 +263,10 @@ document.addEventListener('DOMContentLoaded',()=>{
       if(editingPlantId){ data.append('id', editingPlantId); resp=await fetch('api/update_plant.php',{method:'POST',body:data}); }
       else{ resp=await fetch('api/add_plant.php',{method:'POST',body:data}); }
       if(!resp.ok) throw new Error();
-      alert(editingPlantId?'Plant updated!':'Plant added!');
+      showToast(editingPlantId?'Plant updated!':'Plant added!');
       resetForm(); loadPlants();
     }catch{
-      alert('An error occurred. Please try again.');
+      showToast('An error occurred. Please try again.', true);
     }finally{
       btn.disabled=false;
       btn.textContent=editingPlantId? 'Update Plant':'Add Plant';

--- a/style.css
+++ b/style.css
@@ -78,3 +78,29 @@ input, button {
   margin-bottom: 1rem;
   font-weight: bold;
 }
+
+/* toast notification */
+.toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: #fff;
+  padding: 10px 20px;
+  border-radius: 5px;
+  z-index: 1000;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  display: none;
+}
+
+.toast.show {
+  display: block;
+  opacity: 1;
+}
+
+.toast.error {
+  background: #b00020;
+}


### PR DESCRIPTION
## Summary
- add a toast container to the HTML
- style toast messages
- implement a `showToast` helper in JS
- replace `alert()` calls with toast notifications

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6859edb9338c8324a01f5b6f09b78852