### PR TITLE
Add notes and photo support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ node_modules/
 *.swo
 *.tmp
 db.php
+uploads/*
+!uploads/.gitkeep

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This is a simple PHP-based application for tracking plants.
 You can filter plants that need watering or fertilizing to focus on urgent tasks.
+Each plant can also store free-form notes and an optional photo.
 
 ## Running Tests
 
@@ -30,4 +31,7 @@ Set the following environment variables so `db.php` can establish the database c
 `db.php` reads these values using `getenv`. Ensure the variables are available in
 your environment (or defined in a `.env` file loaded by your web server) before
 running the application so credentials are not stored in the codebase.
+
+The database table should include additional `notes` (TEXT) and `photo` (VARCHAR)
+columns to store the optional fields.
 

--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -24,22 +24,34 @@ $watering_frequency = intval($_POST['watering_frequency'] ?? 0);
 $fertilizing_frequency = intval($_POST['fertilizing_frequency'] ?? 0);
 $last_watered = $_POST['last_watered'] ?? null;
 $last_fertilized = $_POST['last_fertilized'] ?? null;
+$notes = trim($_POST['notes'] ?? '');
+$photo_path = null;
+if (isset($_FILES['photo']) && is_uploaded_file($_FILES['photo']['tmp_name'])) {
+    $ext = pathinfo($_FILES['photo']['name'], PATHINFO_EXTENSION);
+    $filename = uniqid('plant_', true) . ($ext ? ".{$ext}" : '');
+    $target = __DIR__ . '/../uploads/' . $filename;
+    if (move_uploaded_file($_FILES['photo']['tmp_name'], $target)) {
+        $photo_path = 'uploads/' . $filename;
+    }
+}
 
 // Prepare and execute
 $stmt = $conn->prepare("
     INSERT INTO plants (
-        name, species, room, watering_frequency, fertilizing_frequency, last_watered, last_fertilized
-    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        name, species, room, watering_frequency, fertilizing_frequency, last_watered, last_fertilized, notes, photo
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 ");
 $stmt->bind_param(
-    "sssiiss",
+    "sssiissss",
     $name,
     $species,
     $room,
     $watering_frequency,
     $fertilizing_frequency,
     $last_watered,
-    $last_fertilized
+    $last_fertilized,
+    $notes,
+    $photo_path
 );
 
 $stmt->execute();

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -12,7 +12,7 @@ header('Content-Type: application/json');
 
 $plants = [];
 $result = $conn->query("
-    SELECT id, name, species, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized 
+    SELECT id, name, species, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, notes, photo
     FROM plants 
     ORDER BY id DESC
 ");

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -15,6 +15,16 @@ $watering_frequency      = intval($_POST['watering_frequency'] ?? 0);
 $fertilizing_frequency   = intval($_POST['fertilizing_frequency'] ?? 0);
 $last_watered            = $_POST['last_watered'] ?: null;
 $last_fertilized         = $_POST['last_fertilized'] ?: null;
+$notes                   = trim($_POST['notes'] ?? '');
+$photo_path              = null;
+if (isset($_FILES['photo']) && is_uploaded_file($_FILES['photo']['tmp_name'])) {
+    $ext = pathinfo($_FILES['photo']['name'], PATHINFO_EXTENSION);
+    $filename = uniqid('plant_', true) . ($ext ? ".{$ext}" : '');
+    $target = __DIR__ . '/../uploads/' . $filename;
+    if (move_uploaded_file($_FILES['photo']['tmp_name'], $target)) {
+        $photo_path = 'uploads/' . $filename;
+    }
+}
 
 // Basic validation
 if (!$id || $name === '' || $watering_frequency <= 0) {
@@ -32,11 +42,13 @@ $stmt = $conn->prepare("
         watering_frequency = ?,
         fertilizing_frequency = ?,
         last_watered       = ?,
-        last_fertilized    = ?
+        last_fertilized    = ?,
+        notes              = ?,
+        photo              = COALESCE(?, photo)
     WHERE id = ?
 ");
 $stmt->bind_param(
-    'sssiiisi',
+    'sssiiisssi',
     $name,
     $species,
     $room,
@@ -44,6 +56,8 @@ $stmt->bind_param(
     $fertilizing_frequency,
     $last_watered,
     $last_fertilized,
+    $notes,
+    $photo_path,
     $id
 );
 

--- a/index.html
+++ b/index.html
@@ -44,6 +44,12 @@
         <label for="last_fertilized">Last Fertilized</label>
         <input type="date" name="last_fertilized" id="last_fertilized" />
 
+        <label for="notes">Notes</label>
+        <textarea name="notes" id="notes" placeholder="Optional notes"></textarea>
+
+        <label for="photo">Photo</label>
+        <input type="file" name="photo" id="photo" accept="image/*" />
+
         <button type="submit">Add Plant</button>
         <button type="button" id="cancel-edit" style="display:none;">Cancel</button>
     </form>

--- a/script.js
+++ b/script.js
@@ -114,6 +114,9 @@ async function updatePlantInline(plant, field, newValue) {
   data.append('room', plant.room);
   data.append('last_watered', plant.last_watered || '');
   data.append('last_fertilized', plant.last_fertilized || '');
+  if (plant.notes !== undefined) {
+    data.append('notes', plant.notes);
+  }
 
   data.set(field, newValue);
 
@@ -138,6 +141,10 @@ function populateForm(plant) {
   form.room.value = plant.room;
   form.last_watered.value = plant.last_watered;
   form.last_fertilized.value = plant.last_fertilized;
+  form.notes.value = plant.notes || '';
+  if (form.photo) {
+    form.photo.value = '';
+  }
   editingPlantId = plant.id;
 
   const submitBtn = form.querySelector('button[type="submit"]');
@@ -216,7 +223,7 @@ async function loadPlants() {
     const table = document.createElement('table');
     table.classList.add('plant-table');
     const thead = document.createElement('thead');
-    thead.innerHTML = '<tr><th>Name</th><th>Species</th><th>Frequencies</th><th>Actions</th></tr>';
+    thead.innerHTML = '<tr><th>Name</th><th>Species</th><th>Frequencies</th><th>Notes</th><th>Photo</th><th>Actions</th></tr>';
     table.appendChild(thead);
     const tbody = document.createElement('tbody');
 
@@ -253,6 +260,20 @@ async function loadPlants() {
       freqTd.appendChild(document.createElement('br'));
       freqTd.appendChild(roomInput);
       row.appendChild(freqTd);
+
+      const notesTd = document.createElement('td');
+      notesTd.textContent = plant.notes || '';
+      row.appendChild(notesTd);
+
+      const photoTd = document.createElement('td');
+      if (plant.photo) {
+        const img = document.createElement('img');
+        img.src = plant.photo;
+        img.alt = 'plant photo';
+        img.width = 50;
+        photoTd.appendChild(img);
+      }
+      row.appendChild(photoTd);
 
       const actionsTd = document.createElement('td');
 

--- a/style.css
+++ b/style.css
@@ -130,3 +130,7 @@ input, button {
   padding: 8px;
 
 }
+
+.plant-table img {
+  max-height: 50px;
+}


### PR DESCRIPTION
## Summary
- store free-form notes and optional photos for plants
- show notes/photo in the plant table
- allow uploading a plant image
- keep uploaded files out of the repo

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6859fe5d89048324881ccef0569a1f46