### PR TITLE
Add analytics page with charts

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Plant Analytics</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>📊 Plant Analytics</h1>
+    <nav>
+        <a href="index.html">← Back to Plants</a>
+    </nav>
+
+    <h2>Most Watered Plants</h2>
+    <canvas id="waterChart" aria-label="Most watered plants chart" role="img"></canvas>
+
+    <h2>Average Care Frequency</h2>
+    <table id="avg-table" class="plant-table">
+        <thead>
+            <tr><th>Action</th><th>Average Frequency (days)</th></tr>
+        </thead>
+        <tbody>
+            <tr><td>Watering</td><td id="avg-water">-</td></tr>
+            <tr><td>Fertilizing</td><td id="avg-fert">-</td></tr>
+        </tbody>
+    </table>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="analytics.js"></script>
+</body>
+</html>

--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,35 @@
+fetch('api/get_history.php')
+  .then(r => r.json())
+  .then(data => {
+    const sorted = (data.mostWatered || []).sort((a,b) => a.watering_frequency - b.watering_frequency);
+    const labels = sorted.map(p => p.name);
+    const values = sorted.map(p => p.watering_frequency ? (30 / p.watering_frequency) : 0);
+
+    if (labels.length) {
+      const ctx = document.getElementById('waterChart').getContext('2d');
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [{
+            label: 'Estimated waterings per month',
+            data: values,
+            backgroundColor: 'rgba(54, 162, 235, 0.5)'
+          }]
+        },
+        options: {
+          scales: { y: { beginAtZero: true } }
+        }
+      });
+    }
+
+    if (data.averages) {
+      const avgWater = document.getElementById('avg-water');
+      const avgFert = document.getElementById('avg-fert');
+      if (avgWater) avgWater.textContent = Number(data.averages.watering).toFixed(1);
+      if (avgFert) avgFert.textContent = Number(data.averages.fertilizing).toFixed(1);
+    }
+  })
+  .catch(err => {
+    console.error('Analytics load failed', err);
+  });

--- a/api/get_history.php
+++ b/api/get_history.php
@@ -1,0 +1,41 @@
+<?php
+$dbConfig = getenv('DB_CONFIG');
+if ($dbConfig && file_exists($dbConfig)) {
+    include $dbConfig;
+} else {
+    include '../db.php';
+}
+
+header('Content-Type: application/json');
+
+$result = $conn->query(
+    "SELECT name, watering_frequency, fertilizing_frequency FROM plants"
+);
+
+$plants = [];
+$waterTotal = 0;
+$fertTotal = 0;
+$count = 0;
+while ($row = $result->fetch_assoc()) {
+    $row['watering_frequency'] = (int)$row['watering_frequency'];
+    $row['fertilizing_frequency'] = (int)$row['fertilizing_frequency'];
+    $plants[] = $row;
+    $waterTotal += $row['watering_frequency'];
+    $fertTotal += $row['fertilizing_frequency'];
+    $count++;
+}
+
+usort($plants, function($a, $b) {
+    return $a['watering_frequency'] <=> $b['watering_frequency'];
+});
+
+$data = [
+    'mostWatered' => $plants,
+    'averages' => [
+        'watering' => $count ? $waterTotal / $count : 0,
+        'fertilizing' => $count ? $fertTotal / $count : 0
+    ]
+];
+
+echo json_encode($data);
+?>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
     <h1>🌿 My Plant Tracker</h1>
+    <nav><a href="analytics.html">View Analytics</a></nav>
 <div id="summary" class="summary-banner">
   <!-- counts will go here -->
 </div>


### PR DESCRIPTION
## Summary
- add `analytics.html` and `analytics.js` for basic analytics
- expose aggregated data via `api/get_history.php`
- link analytics from `index.html`

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6859ff914d44832498db564a46ce4072