### PR TITLE
Add unit tests for plant event APIs

### DIFF
--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -6,6 +6,8 @@ class ApiTest extends TestCase
     private $dbConfig;
     protected function setUp(): void
     {
+        // Ensure the environment variables set in bootstrap remain consistent
+        // for each individual test case.
         $this->dbConfig = __DIR__ . '/db_stub.php';
         putenv('DB_CONFIG=' . $this->dbConfig);
         putenv('TESTING=1');
@@ -35,11 +37,63 @@ class ApiTest extends TestCase
     public function testGetHistoryReturnsArray()
     {
         $_GET = [];
+        $handler = set_error_handler(function ($errno, $errstr) {
+            return str_contains($errstr, 'headers already sent');
+        }, E_WARNING);
         ob_start();
         include __DIR__ . '/../api/get_history.php';
         $output = ob_get_clean();
+        restore_error_handler();
         $data = json_decode($output, true);
         $this->assertIsArray($data);
+    }
+
+    public function testMarkWateredReturnsSuccess()
+    {
+        $_POST = ['id' => 1];
+        $expected = (new DateTime())->format('Y-m-d');
+
+        ob_start();
+        include __DIR__ . '/../api/mark_watered.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+
+        $this->assertEquals('success', $data['status']);
+        $this->assertEquals($expected, $data['updated']);
+    }
+
+    public function testMarkFertilizedReturnsSuccess()
+    {
+        $_POST = ['id' => 2, 'snooze_days' => 3];
+        $date = new DateTime();
+        $date->modify('+3 days');
+        $expected = $date->format('Y-m-d');
+
+        ob_start();
+        include __DIR__ . '/../api/mark_fertilized.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+
+        $this->assertEquals('success', $data['status']);
+        $this->assertEquals($expected, $data['updated']);
+    }
+
+    public function testGetHistoryStructure()
+    {
+        $_GET = [];
+        $handler = set_error_handler(function ($errno, $errstr) {
+            return str_contains($errstr, 'headers already sent');
+        }, E_WARNING);
+        ob_start();
+        include __DIR__ . '/../api/get_history.php';
+        $output = ob_get_clean();
+        restore_error_handler();
+        $data = json_decode($output, true);
+
+        $this->assertArrayHasKey('mostWatered', $data);
+        $this->assertArrayHasKey('averages', $data);
+        $this->assertIsArray($data['mostWatered']);
+        $this->assertIsArray($data['averages']);
     }
 }
 ?>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,2 +1,10 @@
 <?php
 // Bootstrap for tests
+
+// Point the application to the stub database configuration used by the test
+// suite. Each API script checks the DB_CONFIG environment variable and includes
+// that file if it exists.
+putenv('DB_CONFIG=' . __DIR__ . '/db_stub.php');
+
+// Enable a TESTING flag so scripts can adjust behavior if needed.
+putenv('TESTING=1');


### PR DESCRIPTION
## Summary
- set DB_CONFIG in tests/bootstrap.php for consistent stubbing
- extend ApiTest with coverage for marking plants watered/fertilized
- validate structure of get_history endpoint

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685a0665faa08324aef240f0b57fa05e