### PR TITLE
Add notes and photo upload support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ node_modules/
 *.swo
 *.tmp
 db.php
+uploads/

--- a/README.md
+++ b/README.md
@@ -48,3 +48,15 @@ CREATE TABLE plant_events (
 
 The endpoint `api/get_history.php` returns aggregated counts of events per plant.
 
+## Notes and Photos
+
+Plants can optionally store text notes and a photo. Update your database table to include these columns:
+
+```sql
+ALTER TABLE plants
+  ADD COLUMN notes TEXT,
+  ADD COLUMN photo_path VARCHAR(255);
+```
+
+Uploaded images are saved in the `uploads/` directory.
+

--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -24,22 +24,40 @@ $watering_frequency = intval($_POST['watering_frequency'] ?? 0);
 $fertilizing_frequency = intval($_POST['fertilizing_frequency'] ?? 0);
 $last_watered = $_POST['last_watered'] ?? null;
 $last_fertilized = $_POST['last_fertilized'] ?? null;
+$notes = trim($_POST['notes'] ?? '');
+
+$photoPath = null;
+if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
+    $uploadDir = __DIR__ . '/../uploads/';
+    if (!is_dir($uploadDir)) {
+        mkdir($uploadDir, 0777, true);
+    }
+    $ext = pathinfo($_FILES['photo']['name'], PATHINFO_EXTENSION);
+    $fileName = uniqid('plant_', true) . '.' . $ext;
+    $target = $uploadDir . $fileName;
+    if (move_uploaded_file($_FILES['photo']['tmp_name'], $target)) {
+        $photoPath = 'uploads/' . $fileName;
+    }
+}
 
 // Prepare and execute
 $stmt = $conn->prepare("
     INSERT INTO plants (
-        name, species, room, watering_frequency, fertilizing_frequency, last_watered, last_fertilized
-    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        name, species, room, watering_frequency, fertilizing_frequency,
+        last_watered, last_fertilized, notes, photo_path
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 ");
 $stmt->bind_param(
-    "sssiiss",
+    "sssiissss",
     $name,
     $species,
     $room,
     $watering_frequency,
     $fertilizing_frequency,
     $last_watered,
-    $last_fertilized
+    $last_fertilized,
+    $notes,
+    $photoPath
 );
 
 $stmt->execute();

--- a/api/get_history.php
+++ b/api/get_history.php
@@ -34,7 +34,9 @@ if ($stmt && $stmt->execute()) {
 }
 
 
-header('Content-Type: application/json');
+if (!headers_sent()) {
+    header('Content-Type: application/json');
+}
 
 $result = $conn->query(
     "SELECT name, watering_frequency, fertilizing_frequency FROM plants"

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -12,7 +12,8 @@ header('Content-Type: application/json');
 
 $plants = [];
 $result = $conn->query("
-    SELECT id, name, species, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized 
+    SELECT id, name, species, watering_frequency, fertilizing_frequency, room,
+           last_watered, last_fertilized, notes, photo_path
     FROM plants 
     ORDER BY id DESC
 ");

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -15,6 +15,21 @@ $watering_frequency      = intval($_POST['watering_frequency'] ?? 0);
 $fertilizing_frequency   = intval($_POST['fertilizing_frequency'] ?? 0);
 $last_watered            = $_POST['last_watered'] ?: null;
 $last_fertilized         = $_POST['last_fertilized'] ?: null;
+$notes                   = trim($_POST['notes'] ?? '');
+$photo_path              = $_POST['photo_path'] ?? null;
+
+if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
+    $uploadDir = __DIR__ . '/../uploads/';
+    if (!is_dir($uploadDir)) {
+        mkdir($uploadDir, 0777, true);
+    }
+    $ext = pathinfo($_FILES['photo']['name'], PATHINFO_EXTENSION);
+    $fileName = uniqid('plant_', true) . '.' . $ext;
+    $target = $uploadDir . $fileName;
+    if (move_uploaded_file($_FILES['photo']['tmp_name'], $target)) {
+        $photo_path = 'uploads/' . $fileName;
+    }
+}
 
 // Basic validation
 if (!$id || $name === '' || $watering_frequency <= 0) {
@@ -25,18 +40,20 @@ if (!$id || $name === '' || $watering_frequency <= 0) {
 
 // Prepare update statement
 $stmt = $conn->prepare("
-    UPDATE plants 
+    UPDATE plants
     SET name               = ?,
         species            = ?,
         room               = ?,
         watering_frequency = ?,
         fertilizing_frequency = ?,
         last_watered       = ?,
-        last_fertilized    = ?
+        last_fertilized    = ?,
+        notes              = ?,
+        photo_path         = ?
     WHERE id = ?
 ");
 $stmt->bind_param(
-    'sssiiisi',
+    'sssiiisssi',
     $name,
     $species,
     $room,
@@ -44,6 +61,8 @@ $stmt->bind_param(
     $fertilizing_frequency,
     $last_watered,
     $last_fertilized,
+    $notes,
+    $photo_path,
     $id
 );
 

--- a/index.html
+++ b/index.html
@@ -46,6 +46,13 @@
         <label for="last_fertilized">Last Fertilized</label>
         <input type="date" name="last_fertilized" id="last_fertilized" />
 
+        <label for="notes">Notes</label>
+        <textarea name="notes" id="notes" placeholder="e.g. moved to direct sun"></textarea>
+
+        <label for="photo">Photo</label>
+        <input type="file" name="photo" id="photo" accept="image/*" />
+        <input type="hidden" name="photo_path" id="photo_path_hidden" />
+
         <button type="submit">Add Plant</button>
         <button type="button" id="cancel-edit" style="display:none;">Cancel</button>
     </form>

--- a/script.js
+++ b/script.js
@@ -114,6 +114,8 @@ async function updatePlantInline(plant, field, newValue) {
   data.append('room', plant.room);
   data.append('last_watered', plant.last_watered || '');
   data.append('last_fertilized', plant.last_fertilized || '');
+  data.append('notes', plant.notes || '');
+  data.append('photo_path', plant.photo_path || '');
 
   data.set(field, newValue);
 
@@ -138,6 +140,8 @@ function populateForm(plant) {
   form.room.value = plant.room;
   form.last_watered.value = plant.last_watered;
   form.last_fertilized.value = plant.last_fertilized;
+  form.notes.value = plant.notes || '';
+  document.getElementById('photo_path_hidden').value = plant.photo_path || '';
   editingPlantId = plant.id;
 
   const submitBtn = form.querySelector('button[type="submit"]');
@@ -148,6 +152,7 @@ function populateForm(plant) {
 function resetForm() {
   const form = document.getElementById('plant-form');
   form.reset();
+  document.getElementById('photo_path_hidden').value = '';
   editingPlantId = null;
   form.querySelector('button[type="submit"]').textContent = 'Add Plant';
   document.getElementById('cancel-edit').style.display = 'none';
@@ -216,7 +221,7 @@ async function loadPlants() {
     const table = document.createElement('table');
     table.classList.add('plant-table');
     const thead = document.createElement('thead');
-    thead.innerHTML = '<tr><th>Name</th><th>Species</th><th>Frequencies</th><th>Actions</th></tr>';
+    thead.innerHTML = '<tr><th>Name</th><th>Species</th><th>Frequencies</th><th>Notes</th><th>Photo</th><th>Actions</th></tr>';
     table.appendChild(thead);
     const tbody = document.createElement('tbody');
 
@@ -253,6 +258,24 @@ async function loadPlants() {
       freqTd.appendChild(document.createElement('br'));
       freqTd.appendChild(roomInput);
       row.appendChild(freqTd);
+
+      const notesTd = document.createElement('td');
+      const notesInput = document.createElement('textarea');
+      notesInput.rows = 1;
+      notesInput.value = plant.notes || '';
+      notesInput.onblur = () => updatePlantInline(plant,'notes',notesInput.value);
+      notesTd.appendChild(notesInput);
+      row.appendChild(notesTd);
+
+      const photoTd = document.createElement('td');
+      if (plant.photo_path) {
+        const img = document.createElement('img');
+        img.src = plant.photo_path;
+        img.alt = '';
+        img.style.maxWidth = '50px';
+        photoTd.appendChild(img);
+      }
+      row.appendChild(photoTd);
 
       const actionsTd = document.createElement('td');
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -21,6 +21,17 @@ class ApiTest extends TestCase
         $this->assertArrayHasKey('error', $data);
     }
 
+    public function testAddPlantWithNotes()
+    {
+        $_POST = ['name' => 'Rose', 'notes' => 'test note'];
+        $_FILES = [];
+        ob_start();
+        include __DIR__ . '/../api/add_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('success', $data['status']);
+    }
+
     public function testDeletePlantMissingId()
     {
         $_POST = [];


### PR DESCRIPTION
## Summary
- allow notes and photos in the plant form
- store notes and uploaded photo paths in plants table
- display and edit notes inline and show plant photos
- document notes/photo features
- ignore uploads directory
- add regression tests and fix header warnings

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685a05b23ebc8324a16fe4203fc46306