### PR TITLE
Enhance palette and snackbar accent

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,8 @@
                              bottom: calc(var(--spacing) * 1.25);
                              left:50%;
                              transform:translateX(-50%);
-                             background: var(--color-text);
+                             background: var(--color-accent);
+                             accent-color: var(--color-accent);
                              color: var(--color-bg);
                              padding: calc(var(--spacing) * 1.25);
                              border-radius: var(--radius);

--- a/style.css
+++ b/style.css
@@ -9,6 +9,18 @@
   --spacing: 8px;
 }
 
+/* Dark mode variables maintain accessible contrast ratios */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg: #121212;
+    --color-surface: #1e1e1e;
+    --color-text: #f0f0f0;
+    --color-border: #555;
+    --color-primary: #58a6ff;
+    --color-accent: #cf6679;
+  }
+}
+
 body {
     font-family: sans-serif;
     padding: calc(var(--spacing) * 2.5);


### PR DESCRIPTION
## Summary
- add dark mode variables for accessible contrast
- use `--color-accent` for undo snackbar styling

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685a106107648324880d26edb0c46118