### PR TITLE
Improve input validation

### DIFF
--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -26,6 +26,26 @@ $last_watered = $_POST['last_watered'] ?? null;
 $last_fertilized = $_POST['last_fertilized'] ?? null;
 $photo_url = trim($_POST['photo_url'] ?? '');
 
+// further validation
+$errors = [];
+if ($species !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,100}$/', $species)) {
+    $errors[] = 'Invalid species';
+}
+if ($room !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,50}$/', $room)) {
+    $errors[] = 'Invalid room';
+}
+if ($watering_frequency < 1 || $watering_frequency > 365) {
+    $errors[] = 'Watering frequency must be 1-365';
+}
+if ($errors) {
+    http_response_code(400);
+    echo json_encode(['error' => implode('; ', $errors)]);
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
+}
+
 // Handle uploaded photo
 if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
     $uploadDir = __DIR__ . '/../uploads/';

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -17,6 +17,24 @@ $last_watered            = $_POST['last_watered'] ?: null;
 $last_fertilized         = $_POST['last_fertilized'] ?: null;
 $photo_url               = trim($_POST['photo_url'] ?? '');
 
+// further validation
+$errors = [];
+if ($species !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,100}$/', $species)) {
+    $errors[] = 'Invalid species';
+}
+if ($room !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,50}$/', $room)) {
+    $errors[] = 'Invalid room';
+}
+if ($watering_frequency < 1 || $watering_frequency > 365) {
+    $errors[] = 'Watering frequency must be 1-365';
+}
+
+if ($errors) {
+    http_response_code(400);
+    echo json_encode(['error' => implode('; ', $errors)]);
+    exit;
+}
+
 // Handle uploaded photo
 if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
     $uploadDir = __DIR__ . '/../uploads/';
@@ -31,9 +49,9 @@ if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
 }
 
 // Basic validation
-if (!$id || $name === '' || $watering_frequency <= 0) {
+if (!$id || $name === '') {
     http_response_code(400);
-    echo json_encode(['error' => 'Missing or invalid fields']);
+    echo json_encode(['error' => 'Missing id or name']);
     exit;
 }
 

--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
 
         <label for="room">Room</label>
         <input type="text" name="room" id="room" placeholder="Room" />
+        <div class="error" id="room-error"></div>
 
         <label for="last_watered">Last Watered</label>
         <input type="date" name="last_watered" id="last_watered" />

--- a/script.js
+++ b/script.js
@@ -29,6 +29,33 @@ function validateForm(form) {
     }
   });
 
+  // additional constraints
+  const species = form.querySelector('[name="species"]');
+  if (species && species.value.trim() &&
+      !/^[A-Za-z0-9\s-]{1,100}$/.test(species.value.trim())) {
+    document.getElementById('species-error').textContent =
+      'Invalid characters or too long.';
+    valid = false;
+  }
+
+  const room = form.querySelector('[name="room"]');
+  if (room && room.value.trim() &&
+      !/^[A-Za-z0-9\s-]{1,50}$/.test(room.value.trim())) {
+    document.getElementById('room-error').textContent =
+      'Invalid characters or too long.';
+    valid = false;
+  }
+
+  const waterFreq = form.querySelector('[name="watering_frequency"]');
+  if (waterFreq) {
+    const n = parseInt(waterFreq.value, 10);
+    if (isNaN(n) || n < 1 || n > 365) {
+      document.getElementById('watering_frequency-error').textContent =
+        'Enter a value between 1 and 365.';
+      valid = false;
+    }
+  }
+
   return valid;
 }
 


### PR DESCRIPTION
## Summary
- validate plant forms more strictly on the client
- add matching validation checks to `add_plant` and `update_plant` endpoints
- show room validation errors in the HTML form

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685a9055d6dc8324a4994e7e17abf3e7