### PR TITLE
Improve API error handling

### DIFF
--- a/api/delete_plant.php
+++ b/api/delete_plant.php
@@ -6,14 +6,36 @@ if ($dbConfig && file_exists($dbConfig)) {
     include('../db.php');
 }
 
+if (!headers_sent()) {
+    header('Content-Type: application/json');
+}
+
 $id = $_POST['id'] ?? null;
 
-if ($id) {
-    $stmt = $conn->prepare("DELETE FROM plants WHERE id = ?");
-    $stmt->bind_param("i", $id);
-    $stmt->execute();
+if (!$id) {
+    @http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'No ID provided']);
+    return;
+}
+
+$stmt = $conn->prepare("DELETE FROM plants WHERE id = ?");
+if (!$stmt) {
+    @http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error', 'details' => $conn->error]);
+    return;
+}
+$stmt->bind_param("i", $id);
+if (!$stmt->execute()) {
+    @http_response_code(500);
+    echo json_encode(['success' => false, 'error' => 'Database error', 'details' => $stmt->error]);
+    return;
+}
+
+if ($stmt->affected_rows > 0) {
+    @http_response_code(200);
     echo json_encode(['success' => true]);
 } else {
-    echo json_encode(['success' => false, 'error' => 'No ID provided']);
+    @http_response_code(404);
+    echo json_encode(['success' => false, 'error' => 'Plant not found']);
 }
 ?>

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -8,14 +8,21 @@ if ($dbConfig && file_exists($dbConfig)) {
     include '../db.php';
 }
 
-header('Content-Type: application/json');
+if (!headers_sent()) {
+    header('Content-Type: application/json');
+}
 
 $plants = [];
- $result = $conn->query("
-     SELECT id, name, species, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url
-     FROM plants
-     ORDER BY id DESC
- ");
+$result = $conn->query(
+    "SELECT id, name, species, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url
+    FROM plants
+    ORDER BY id DESC"
+);
+if (!$result) {
+    @http_response_code(500);
+    echo json_encode(['error' => 'Database error', 'details' => $conn->error]);
+    return;
+}
 
 while ($row = $result->fetch_assoc()) {
     $plants[] = $row;

--- a/api/mark_watered.php
+++ b/api/mark_watered.php
@@ -8,8 +8,18 @@ if ($dbConfig && file_exists($dbConfig)) {
     include '../db.php';
 }
 
+if (!headers_sent()) {
+    header('Content-Type: application/json');
+}
+
 $id = intval($_POST['id']);
 $snooze = isset($_POST['snooze_days']) ? intval($_POST['snooze_days']) : 0;
+
+if ($id <= 0) {
+    @http_response_code(400);
+    echo json_encode(['status' => 'error', 'error' => 'Invalid plant ID']);
+    return;
+}
 
 $date = new DateTime();
 if ($snooze > 0) {
@@ -18,9 +28,20 @@ if ($snooze > 0) {
 $today = $date->format('Y-m-d');
 
 $stmt = $conn->prepare("UPDATE plants SET last_watered = ? WHERE id = ?");
+if (!$stmt) {
+    @http_response_code(500);
+    echo json_encode(['status' => 'error', 'error' => 'Database error', 'details' => $conn->error]);
+    return;
+}
 $stmt->bind_param("si", $today, $id);
-$stmt->execute();
+if (!$stmt->execute()) {
+    @http_response_code(500);
+    echo json_encode(['status' => 'error', 'error' => 'Database error', 'details' => $stmt->error]);
+    return;
+}
 $stmt->close();
+
+@http_response_code(200);
 
 echo json_encode(['status' => 'success', 'updated' => $today]);
 ?>

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -6,6 +6,10 @@ if ($dbConfig && file_exists($dbConfig)) {
     include '../db.php';
 }
 
+if (!headers_sent()) {
+    header('Content-Type: application/json');
+}
+
 // Collect and sanitize
 $id                      = intval($_POST['id'] ?? 0);
 $name                    = trim($_POST['name'] ?? '');
@@ -32,7 +36,7 @@ if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
 
 // Basic validation
 if (!$id || $name === '' || $watering_frequency <= 0) {
-    http_response_code(400);
+    @http_response_code(400);
     echo json_encode(['error' => 'Missing or invalid fields']);
     exit;
 }
@@ -64,10 +68,11 @@ $stmt->bind_param(
 );
 
 if (!$stmt->execute()) {
-    http_response_code(500);
+    @http_response_code(500);
     echo json_encode(['error' => 'Database error', 'details' => $stmt->error]);
     exit;
 }
 
 $stmt->close();
+@http_response_code(200);
 echo json_encode(['status' => 'success']);


### PR DESCRIPTION
## Summary
- send JSON headers cautiously when not already sent
- return HTTP codes and detailed error messages from API scripts

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685a9064fae48324897017fe58d3ade6