### PR TITLE
Fix plant photo sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -181,13 +181,13 @@ textarea {
 .plant-table input:focus {
   outline: none;
   border-bottom: 1px dashed var(--color-border);
+}
 
 .plant-photo {
   width: 60px;
   height: 60px;
   object-fit: cover;
   border-radius: var(--radius);
-
 }
 
 /* simple calendar styles */


### PR DESCRIPTION
## Summary
- close `.plant-table input:focus` rule in `style.css`
- allow `.plant-photo` rules to apply so images are 60px

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685a9ac8f9b083248fecbeabe2e23319