### PR TITLE
Improve form layout with helper text

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,33 +21,53 @@
     <button id="show-add-form">Add a Plant</button>
 
     <form id="plant-form" style="display:none;" enctype="multipart/form-data">
-        <label for="name">Plant Name</label>
-        <input type="text" name="name" id="name" placeholder="Plant Name" />
-        <div class="error" id="name-error"></div>
+        <div class="form-grid">
+            <div class="form-control">
+                <label for="name">Plant Name</label>
+                <input type="text" name="name" id="name" placeholder="Plant Name" />
+                <div class="error" id="name-error"></div>
+            </div>
 
-        <label for="species">Species</label>
-        <input type="text" name="species" id="species" placeholder="Species" />
-        <div class="error" id="species-error"></div>
+            <div class="form-control">
+                <label for="species">Species</label>
+                <input type="text" name="species" id="species" placeholder="Species" />
+                <div class="error" id="species-error"></div>
+            </div>
 
-        <label for="watering_frequency">Watering Frequency (days)</label>
-        <input type="number" name="watering_frequency" id="watering_frequency" />
-        <div class="error" id="watering_frequency-error"></div>
+            <div class="form-control">
+                <label for="watering_frequency">Watering Frequency (days)</label>
+                <input type="number" name="watering_frequency" id="watering_frequency" placeholder="e.g. 7" />
+                <small class="helper-text">e.g. every 7 days</small>
+                <div class="error" id="watering_frequency-error"></div>
+            </div>
 
-        <label for="fertilizing_frequency">Fertilizing Frequency (days)</label>
-        <input type="number" name="fertilizing_frequency" id="fertilizing_frequency" />
+            <div class="form-control">
+                <label for="fertilizing_frequency">Fertilizing Frequency (days)</label>
+                <input type="number" name="fertilizing_frequency" id="fertilizing_frequency" placeholder="e.g. 30" />
+                <small class="helper-text">e.g. every 30 days</small>
+            </div>
 
-        <label for="photo">Upload Photo</label>
-        <input type="file" id="photo" name="photo" accept="image/*" />
+            <div class="form-control">
+                <label for="photo">Upload Photo</label>
+                <input type="file" id="photo" name="photo" accept="image/*" />
+            </div>
 
-        <label for="room">Room</label>
-        <input type="text" name="room" id="room" placeholder="Room" />
-        <div class="error" id="room-error"></div>
+            <div class="form-control">
+                <label for="room">Room</label>
+                <input type="text" name="room" id="room" placeholder="Room" />
+                <div class="error" id="room-error"></div>
+            </div>
 
-        <label for="last_watered">Last Watered</label>
-        <input type="date" name="last_watered" id="last_watered" />
+            <div class="form-control">
+                <label for="last_watered">Last Watered</label>
+                <input type="date" name="last_watered" id="last_watered" />
+            </div>
 
-        <label for="last_fertilized">Last Fertilized</label>
-        <input type="date" name="last_fertilized" id="last_fertilized" />
+            <div class="form-control">
+                <label for="last_fertilized">Last Fertilized</label>
+                <input type="date" name="last_fertilized" id="last_fertilized" />
+            </div>
+        </div>
 
         <button type="submit">Add Plant</button>
         <button type="button" id="cancel-edit" style="display:none;">Cancel</button>

--- a/style.css
+++ b/style.css
@@ -42,6 +42,29 @@ h3 {
 form {
     margin-bottom: calc(var(--spacing) * 2.5);
 }
+
+#plant-form .form-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--spacing);
+}
+
+#plant-form .form-control {
+    display: flex;
+    flex-direction: column;
+}
+
+#plant-form .helper-text {
+    font-size: 0.85em;
+    color: var(--color-text);
+    margin-top: calc(var(--spacing) / 4);
+}
+
+@media (min-width: 700px) {
+    #plant-form .form-grid {
+        grid-template-columns: 1fr 1fr;
+    }
+}
 input,
 button,
 select,


### PR DESCRIPTION
## Summary
- arrange the plant form into a grid
- stack fields on small screens and display two columns on desktop
- add placeholders and helper text for frequency fields

## Testing
- `phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_685abc18c6088324a6e5ff488dd154a2