### PR TITLE
Improve plant form layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,37 +20,55 @@
 
     <button id="show-add-form">Add a Plant</button>
 
-    <form id="plant-form" style="display:none;" enctype="multipart/form-data">
-        <label for="name">Plant Name</label>
-        <input type="text" name="name" id="name" placeholder="Plant Name" />
-        <div class="error" id="name-error"></div>
+    <form id="plant-form" class="form-grid" style="display:none;" enctype="multipart/form-data">
+        <div class="form-control">
+            <label for="name">Plant Name</label>
+            <input type="text" name="name" id="name" placeholder="Plant Name" />
+            <div class="error" id="name-error"></div>
+        </div>
 
-        <label for="species">Species</label>
-        <input type="text" name="species" id="species" placeholder="Species" />
-        <div class="error" id="species-error"></div>
+        <div class="form-control">
+            <label for="species">Species</label>
+            <input type="text" name="species" id="species" placeholder="Species" />
+            <div class="error" id="species-error"></div>
+        </div>
 
-        <label for="watering_frequency">Watering Frequency (days)</label>
-        <input type="number" name="watering_frequency" id="watering_frequency" />
-        <div class="error" id="watering_frequency-error"></div>
+        <div class="form-control">
+            <label for="watering_frequency">Watering Frequency (days)</label>
+            <input type="number" name="watering_frequency" id="watering_frequency" />
+            <div class="error" id="watering_frequency-error"></div>
+        </div>
 
-        <label for="fertilizing_frequency">Fertilizing Frequency (days)</label>
-        <input type="number" name="fertilizing_frequency" id="fertilizing_frequency" />
+        <div class="form-control">
+            <label for="fertilizing_frequency">Fertilizing Frequency (days)</label>
+            <input type="number" name="fertilizing_frequency" id="fertilizing_frequency" />
+        </div>
 
-        <label for="photo">Upload Photo</label>
-        <input type="file" id="photo" name="photo" accept="image/*" />
+        <div class="form-control">
+            <label for="photo">Upload Photo</label>
+            <input type="file" id="photo" name="photo" accept="image/*" />
+        </div>
 
-        <label for="room">Room</label>
-        <input type="text" name="room" id="room" placeholder="Room" />
-        <div class="error" id="room-error"></div>
+        <div class="form-control">
+            <label for="room">Room</label>
+            <input type="text" name="room" id="room" placeholder="Room" />
+            <div class="error" id="room-error"></div>
+        </div>
 
-        <label for="last_watered">Last Watered</label>
-        <input type="date" name="last_watered" id="last_watered" />
+        <div class="form-control">
+            <label for="last_watered">Last Watered</label>
+            <input type="date" name="last_watered" id="last_watered" />
+        </div>
 
-        <label for="last_fertilized">Last Fertilized</label>
-        <input type="date" name="last_fertilized" id="last_fertilized" />
+        <div class="form-control">
+            <label for="last_fertilized">Last Fertilized</label>
+            <input type="date" name="last_fertilized" id="last_fertilized" />
+        </div>
 
-        <button type="submit">Add Plant</button>
-        <button type="button" id="cancel-edit" style="display:none;">Cancel</button>
+        <div class="form-control full-span">
+            <button type="submit">Add Plant</button>
+            <button type="button" id="cancel-edit" style="display:none;">Cancel</button>
+        </div>
     </form>
 
     <div style="margin-top: calc(var(--spacing) * 2);">

--- a/style.css
+++ b/style.css
@@ -44,6 +44,35 @@ h3 {
 form {
     margin-bottom: calc(var(--spacing) * 2.5);
 }
+
+/* grid layout for plant form */
+#plant-form.form-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: calc(var(--spacing) * 1.5) var(--spacing);
+}
+
+@media (min-width: 700px) {
+    #plant-form.form-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+.form-control {
+    display: flex;
+    flex-direction: column;
+}
+
+.form-control.full-span {
+    grid-column: span 2;
+}
+
+.helper {
+    font-size: 0.85em;
+    color: var(--color-text);
+    opacity: 0.8;
+    margin-top: calc(var(--spacing) / 4);
+}
 input,
 button,
 select,


### PR DESCRIPTION
## Summary
- switch the plant form to a grid layout
- wrap each input in `.form-control` blocks
- add CSS rules for the grid and helper text with a responsive breakpoint

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685ac8097fa083248027c74855d8b7e9