### PR TITLE
Improve summary and snackbar style

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,16 +87,7 @@
         </select>
       </div>
 <!-- Undo delete snackbar -->
-<div id="undo-banner" style="display:none;
-                             position:fixed;
-                             bottom:calc(var(--spacing)*1.25);
-                             left:50%;
-                             transform:translateX(-50%);
-                             background:var(--color-text);
-                             color:var(--color-bg);
-                             padding:calc(var(--spacing)*1.25);
-                             border-radius:var(--radius);
-                             z-index:1000;">
+<div id="undo-banner">
   Plant deleted. <button id="undo-btn">Undo</button>
 </div>
 

--- a/script.js
+++ b/script.js
@@ -206,7 +206,7 @@ async function markAction(id, type, days = 0) {
 function showUndoBanner(plant) {
   lastDeletedPlant = plant;
   const banner = document.getElementById('undo-banner');
-  banner.style.display = 'block';
+  banner.classList.add('show');
   clearTimeout(deleteTimer);
   deleteTimer = setTimeout(async () => {
     await fetch('api/delete_plant.php', {
@@ -214,7 +214,7 @@ function showUndoBanner(plant) {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: `id=${plant.id}`
     });
-    banner.style.display = 'none';
+    banner.classList.remove('show');
     lastDeletedPlant = null;
     loadPlants();
     loadCalendar();
@@ -327,8 +327,10 @@ async function loadPlants() {
       if (nxt <= today) fertilizingDue++;
     }
   });
-  document.getElementById('summary').textContent =
+  const summaryEl = document.getElementById('summary');
+  summaryEl.textContent =
     `🌱 ${totalPlants} plants • 🔔 ${wateringDue} need watering • ${fertilizingDue} need fertilizing`;
+  summaryEl.classList.add('show');
 
   // group + filter
   list.innerHTML = '';
@@ -533,7 +535,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   }
   document.getElementById('undo-btn').addEventListener('click',()=>{
     clearTimeout(deleteTimer);
-    document.getElementById('undo-banner').style.display='none';
+    document.getElementById('undo-banner').classList.remove('show');
     lastDeletedPlant=null;
   });
 

--- a/style.css
+++ b/style.css
@@ -185,20 +185,41 @@ button:focus {
   100% { background-color: transparent; }
 }
 #undo-banner {
-  animation: fadeInOut 5s forwards;
+  position: fixed;
+  bottom: calc(var(--spacing) * 1.25);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--color-text);
+  color: var(--color-bg);
+  padding: calc(var(--spacing) * 1.25) calc(var(--spacing) * 2);
+  border-radius: var(--radius);
+  z-index: 1000;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease, visibility 0s linear 0.3s;
 }
-@keyframes fadeInOut {
-  0%   { opacity: 0; }
-  10%  { opacity: 1; }
-  90%  { opacity: 1; }
-  100% { opacity: 0; }
+
+#undo-banner.show {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transition-delay: 0s;
 }
+
 .summary-banner {
-  background: var(--color-surface);
-  padding: var(--spacing);
+  background: var(--color-accent);
+  color: var(--color-bg);
+  padding: calc(var(--spacing) * 1.25);
   border-radius: var(--radius);
   margin-bottom: calc(var(--spacing) * 2);
   font-weight: bold;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.summary-banner.show {
+  opacity: 1;
 }
 
 /* toast notification */


### PR DESCRIPTION
## Summary
- remove inline styles for the undo banner
- apply fade-in/out animations for summary banner and undo snackbar
- tweak JavaScript to toggle new classes

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685adacb299083248a2079ab9c291ce0