### PR TITLE
Add visible labels to form buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -511,19 +511,19 @@ document.addEventListener('DOMContentLoaded',()=>{
 
   if (showBtn) {
     showBtn.classList.add('action-btn');
-    showBtn.innerHTML = ICONS.plus + '<span class="visually-hidden">Add a Plant</span>';
+    showBtn.innerHTML = ICONS.plus + ' Add a Plant';
   }
   if (cancelBtn) {
     cancelBtn.classList.add('action-btn');
-    cancelBtn.innerHTML = ICONS.cancel + '<span class="visually-hidden">Cancel</span>';
+    cancelBtn.innerHTML = ICONS.cancel + ' Cancel';
   }
   if (undoBtn) {
     undoBtn.classList.add('action-btn');
-    undoBtn.innerHTML = ICONS.undo + '<span class="visually-hidden">Undo</span>';
+    undoBtn.innerHTML = ICONS.undo + ' Undo';
   }
   if (submitBtn) {
     submitBtn.classList.add('action-btn');
-    submitBtn.innerHTML = ICONS.plus + '<span class="visually-hidden">Add Plant</span>';
+    submitBtn.innerHTML = ICONS.plus + ' Add Plant';
   }
   if (showBtn && form) {
     showBtn.addEventListener('click', () => {
@@ -548,7 +548,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     const btn=form.querySelector('button[type="submit"]');
     btn.disabled=true;
     btn.innerHTML=(editingPlantId?ICONS.check:ICONS.plus)+
-                  `<span class="visually-hidden">${editingPlantId?'Updating...':'Adding...'}</span>`;
+                  (editingPlantId?' Updating...':' Adding...');
     try{
       let resp;
       if(editingPlantId){ data.append('id', editingPlantId); resp=await fetch('api/update_plant.php',{method:'POST',body:data}); }
@@ -563,8 +563,8 @@ document.addEventListener('DOMContentLoaded',()=>{
     }finally{
       btn.disabled=false;
       btn.innerHTML=editingPlantId
-        ? ICONS.check + '<span class="visually-hidden">Update Plant</span>'
-        : ICONS.plus + '<span class="visually-hidden">Add Plant</span>';
+        ? ICONS.check + ' Update Plant'
+        : ICONS.plus + ' Add Plant';
     }
   });
 

--- a/style.css
+++ b/style.css
@@ -104,7 +104,7 @@ button:focus {
     justify-content: center;
     align-items: center;
     gap: 4px;
-    width: 2.25rem;
+    min-width: 2.25rem;
     height: 2.25rem;
     padding: calc(var(--spacing) / 2);
     border: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary
- allow `.action-btn` to size based on content
- display text alongside icons for form controls
- keep dynamic submit button text visible when submitting

## Testing
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_685af11da8f08324b11805050366a115