### PR TITLE
Fix form button hover and spacing

### DIFF
--- a/style.css
+++ b/style.css
@@ -86,7 +86,11 @@ input,
 select,
 textarea {
     padding: var(--spacing);
-    margin: calc(var(--spacing) / 2);
+    /*
+     * Margin is removed so spacing relies on the container's
+     * gap. This keeps form elements aligned when using
+     * Tailwind's grid utilities.
+     */
     font-family: inherit;
     font-size: 1rem;
     border: 1px solid var(--color-border);
@@ -101,7 +105,12 @@ button {
 
 button:hover,
 button:focus {
-    background-color: var(--color-surface);
+    /*
+     * Preserve the original background color but slightly
+     * reduce brightness so buttons with custom colors remain
+     * legible on hover or focus.
+     */
+    filter: brightness(95%);
     transform: translateY(-2px);
 }
 


### PR DESCRIPTION
## Summary
- remove margin from inputs so Tailwind grid gap controls spacing
- make button hover state keep original color so text stays readable

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685b34b21b6c8324b3d3b5af3640f4e9