### PR TITLE
Adjust plant card summary layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -396,9 +396,10 @@ button:focus {
 }
 
 .plant-summary {
-  display: flex;
-  gap: calc(var(--spacing));
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  column-gap: calc(var(--spacing));
+  row-gap: calc(var(--spacing));
   margin-bottom: calc(var(--spacing));
 }
 


### PR DESCRIPTION
## Summary
- format plant summary as a two-row grid so first two items stay on one line

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685b35c6460c8324b9c0d4a71936a803