### PR TITLE
Fix due-future card color

### DIFF
--- a/style.css
+++ b/style.css
@@ -388,8 +388,8 @@ button:focus {
   box-shadow: inset 4px 0 0 var(--color-warning), 0 2px 6px rgba(0,0,0,0.1);
 }
 .plant-card.due-future {
-  background-color: var(--color-success-bg);
-  box-shadow: inset 4px 0 0 var(--color-success), 0 2px 6px rgba(0,0,0,0.1);
+  background-color: #ffffff;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
 
 .plant-title {


### PR DESCRIPTION
## Summary
- set `.plant-card.due-future` to use white background and remove green accent

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685b37b59ca08324beef9fd98143cf99