### PR TITLE
Remove text from plant form buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
         </div>
     </div>
 
-    <button id="show-add-form" class="bg-primary text-white rounded-md px-4 py-2 mb-4">Add a Plant</button>
+    <button id="show-add-form" class="bg-primary text-white rounded-md px-4 py-2 mb-4"></button>
 
     <form id="plant-form" class="grid grid-cols-1 sm:grid-cols-2 gap-4 p-4 bg-card rounded-lg shadow hidden" enctype="multipart/form-data">
         <div>
@@ -80,8 +80,8 @@
             <input type="date" name="last_fertilized" id="last_fertilized" class="w-full border rounded-md p-2" />
         </div>
         <div class="sm:col-span-2 flex gap-2 justify-end">
-            <button type="button" id="cancel-edit" class="bg-gray-200 rounded-md px-4 py-2 hidden">Cancel</button>
-            <button type="submit" class="bg-primary text-white rounded-md px-4 py-2">Add Plant</button>
+            <button type="button" id="cancel-edit" class="bg-gray-200 rounded-md px-4 py-2 hidden"></button>
+            <button type="submit" class="bg-primary text-white rounded-md px-4 py-2"></button>
         </div>
     </form>
 

--- a/script.js
+++ b/script.js
@@ -509,16 +509,16 @@ document.addEventListener('DOMContentLoaded',()=>{
   const submitBtn = form ? form.querySelector('button[type="submit"]') : null;
 
   if (showBtn) {
-    showBtn.innerHTML = ICONS.plus + ' Add a Plant';
+    showBtn.innerHTML = ICONS.plus + '<span class="visually-hidden">Add a Plant</span>';
   }
   if (cancelBtn) {
-    cancelBtn.innerHTML = ICONS.cancel + ' Cancel';
+    cancelBtn.innerHTML = ICONS.cancel + '<span class="visually-hidden">Cancel</span>';
   }
   if (undoBtn) {
     undoBtn.innerHTML = ICONS.undo + ' Undo';
   }
   if (submitBtn) {
-    submitBtn.innerHTML = ICONS.plus + ' Add Plant';
+    submitBtn.innerHTML = ICONS.plus + '<span class="visually-hidden">Add Plant</span>';
   }
   if (showBtn && form) {
     showBtn.addEventListener('click', () => {
@@ -558,8 +558,8 @@ document.addEventListener('DOMContentLoaded',()=>{
     }finally{
       btn.disabled=false;
       btn.innerHTML=editingPlantId
-        ? ICONS.check + ' Update Plant'
-        : ICONS.plus + ' Add Plant';
+        ? ICONS.check + '<span class="visually-hidden">Update Plant</span>'
+        : ICONS.plus + '<span class="visually-hidden">Add Plant</span>';
     }
   });
 


### PR DESCRIPTION
## Summary
- drop visible text from the Add Plant form buttons
- keep accessible labels via hidden spans

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685b3a8ebc5c83249be8d9168ef23e27