### PR TITLE
Color plant cards by due task

### DIFF
--- a/script.js
+++ b/script.js
@@ -346,8 +346,6 @@ async function loadPlants() {
     const haystack = (plant.name + ' ' + plant.species).toLowerCase();
     if (searchQuery && !haystack.includes(searchQuery)) return false;
 
-    const waterDue = needsWatering(plant, today);
-    const fertDue = needsFertilizing(plant, today);
     if (dueFilter === 'water' && !waterDue) return false;
     if (dueFilter === 'fert' && !fertDue) return false;
     if (dueFilter === 'any' && !(waterDue || fertDue)) return false;
@@ -375,6 +373,17 @@ async function loadPlants() {
       card.classList.add('due-today');
     } else {
       card.classList.add('due-future');
+    }
+
+    const waterDue = needsWatering(plant, today);
+    const fertDue = needsFertilizing(plant, today);
+
+    if (waterDue && fertDue) {
+      card.classList.add('both-due-card');
+    } else if (waterDue) {
+      card.classList.add('water-due-card');
+    } else if (fertDue) {
+      card.classList.add('fert-due-card');
     }
 
     if (plant.photo_url) {
@@ -426,9 +435,6 @@ async function loadPlants() {
 
     const actionsDiv = document.createElement('div');
     actionsDiv.classList.add('actions');
-
-    const waterDue = needsWatering(plant, today);
-    const fertDue = needsFertilizing(plant, today);
 
     if (waterDue) {
       const btn = document.createElement('button');

--- a/style.css
+++ b/style.css
@@ -400,6 +400,18 @@ button:focus {
   box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
 
+.plant-card.water-due-card {
+  background-color: var(--color-water-bg);
+}
+
+.plant-card.fert-due-card {
+  background-color: var(--color-success-bg);
+}
+
+.plant-card.both-due-card {
+  background-color: var(--color-warning-bg);
+}
+
 .plant-title {
   font-size: 1.25rem;
   font-weight: 600;


### PR DESCRIPTION
## Summary
- add new card classes for watering/fertilizing due colors
- apply card classes based on upcoming tasks

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685b3b7466fc8324bbdc6d2bf4df602a