### PR TITLE
Improve room tag color contrast

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,7 +12,8 @@ function colorForRoom(room) {
       hash = room.charCodeAt(i) + ((hash << 5) - hash);
     }
     const hue = Math.abs(hash) % 360;
-    roomColors[room] = `hsl(${hue}, 60%, 80%)`;
+    // darker, more saturated colors for better contrast with white text
+    roomColors[room] = `hsl(${hue}, 70%, 45%)`;
   }
   return roomColors[room];
 }

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 :root {
   /* Blossom-inspired palette */
   --color-primary: #8d67d6; /* lavender */
-  --color-accent: #ffa5d8; /* pink */
+  --color-accent: #d65f95; /* darker pink for tag contrast */
   --color-bg: #fdf9fd;     /* soft light */
   --color-surface: #ffffff; /* white */
   --color-border: #e5d8ea;


### PR DESCRIPTION
## Summary
- darken accent color for better contrast
- generate darker room colors for readability

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685b53a5c6cc8324a89e547822999ce4