### PR TITLE
Make summary icons green

### DIFF
--- a/style.css
+++ b/style.css
@@ -474,6 +474,7 @@ button:focus {
   width: 1em;
   height: 1em;
   vertical-align: -0.125em;
+  color: var(--color-success);
 }
 
 
@@ -483,6 +484,7 @@ button:focus {
 
 .icon-sprout {
   color: var(--color-success);
+}
 
 .icon-plant {
   color: var(--color-success);


### PR DESCRIPTION
## Summary
- add a green color to icons inside the summary section
- fix missing closing brace for .icon-sprout

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b55abe1048324b1ab4641c6b4b7c1