### PR TITLE
Add water calculator and water amount field

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_HOST=localhost
+DB_USER=your_user
+DB_PASS=your_password
+DB_NAME=your_database

--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -25,6 +25,7 @@ $name = trim($_POST['name']);
 $species = trim($_POST['species'] ?? '');
 $room = trim($_POST['room'] ?? '');
 $watering_frequency = intval($_POST['watering_frequency'] ?? 0);
+$water_amount = floatval($_POST['water_amount'] ?? 0);
 $fertilizing_frequency = intval($_POST['fertilizing_frequency'] ?? 0);
 $last_watered = $_POST['last_watered'] ?? null;
 $last_fertilized = $_POST['last_fertilized'] ?? null;
@@ -40,6 +41,9 @@ if ($room !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,50}$/', $room)) {
 }
 if ($watering_frequency < 1 || $watering_frequency > 365) {
     $errors[] = 'Watering frequency must be 1-365';
+}
+if ($water_amount < 0) {
+    $errors[] = 'Water amount must be positive';
 }
 if ($errors) {
     http_response_code(400);
@@ -74,8 +78,8 @@ if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
 $stmt = $conn->prepare(
     "
     INSERT INTO plants (
-        name, species, room, watering_frequency, fertilizing_frequency, last_watered, last_fertilized, photo_url
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        name, species, room, watering_frequency, water_amount, fertilizing_frequency, last_watered, last_fertilized, photo_url
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
 );
 if (!$stmt) {
     @http_response_code(500);
@@ -86,11 +90,12 @@ if (!$stmt) {
     return;
 }
 $stmt->bind_param(
-    "sssiisss",
+    "sssidisss",
     $name,
     $species,
     $room,
     $watering_frequency,
+    $water_amount,
     $fertilizing_frequency,
     $last_watered,
     $last_fertilized,

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -14,7 +14,7 @@ if (!headers_sent()) {
 
 $plants = [];
 $result = $conn->query(
-    "SELECT id, name, species, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url
+    "SELECT id, name, species, watering_frequency, water_amount, fertilizing_frequency, room, last_watered, last_fertilized, photo_url
     FROM plants
     ORDER BY id DESC"
 );

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -16,6 +16,7 @@ $name                    = trim($_POST['name'] ?? '');
 $species                 = trim($_POST['species'] ?? '');
 $room                    = trim($_POST['room'] ?? '');
 $watering_frequency      = intval($_POST['watering_frequency'] ?? 0);
+$water_amount            = floatval($_POST['water_amount'] ?? 0);
 $fertilizing_frequency   = intval($_POST['fertilizing_frequency'] ?? 0);
 $last_watered            = $_POST['last_watered'] ?: null;
 $last_fertilized         = $_POST['last_fertilized'] ?: null;
@@ -31,6 +32,9 @@ if ($room !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,50}$/', $room)) {
 }
 if ($watering_frequency < 1 || $watering_frequency > 365) {
     $errors[] = 'Watering frequency must be 1-365';
+}
+if ($water_amount < 0) {
+    $errors[] = 'Water amount must be positive';
 }
 
 if ($errors) {
@@ -74,6 +78,7 @@ $stmt = $conn->prepare("
         species            = ?,
         room               = ?,
         watering_frequency = ?,
+        water_amount       = ?,
         fertilizing_frequency = ?,
         last_watered       = ?,
         last_fertilized    = ?,
@@ -81,11 +86,12 @@ $stmt = $conn->prepare("
     WHERE id = ?
 ");
 $stmt->bind_param(
-    'sssiisssi',
+    'sssidisssi',
     $name,
     $species,
     $room,
     $watering_frequency,
+    $water_amount,
     $fertilizing_frequency,
     $last_watered,
     $last_fertilized,

--- a/config.php
+++ b/config.php
@@ -1,0 +1,9 @@
+<?php
+return [
+    'openweather_key' => '2aa3ade8428368a141f7951420570c16',
+    'location' => 'New Brighton,MN,US',
+    'ra' => 20.0,
+    'kc' => 0.8,
+    'pot_diameter_cm' => 20,
+];
+?>

--- a/db.php
+++ b/db.php
@@ -1,8 +1,8 @@
 <?php
-$host = "localhost"; // Leave this as is
-$user = "u568785491_jon"; // Your actual DB user
-$pass = "yS+olgrwgD1";  // ✅ Your new password
-$dbname = "u568785491_plants"; // Your actual DB name
+$host = getenv('DB_HOST') ?: 'localhost';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: '';
+$dbname = getenv('DB_NAME') ?: 'plants';
 
 $conn = new mysqli($host, $user, $pass, $dbname);
 

--- a/index.html
+++ b/index.html
@@ -25,7 +25,6 @@
         }
       }
     </script>
-    <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-bg text-text min-h-screen">
     <h1 class="app-title text-2xl font-bold p-4">
@@ -63,6 +62,11 @@
             <label for="watering_frequency" class="block mb-1">Watering Frequency (days)</label>
             <input type="number" name="watering_frequency" id="watering_frequency" class="w-full border rounded-md p-2" />
             <div class="error" id="watering_frequency-error"></div>
+        </div>
+        <div>
+            <label for="water_amount" class="block mb-1">Water Amount (mL)</label>
+            <input type="number" name="water_amount" id="water_amount" class="w-full border rounded-md p-2" />
+            <div class="error" id="water_amount-error"></div>
         </div>
         <div>
             <label for="fertilizing_frequency" class="block mb-1">Fertilizing Frequency (days)</label>

--- a/script.js
+++ b/script.js
@@ -87,6 +87,16 @@ function validateForm(form) {
     }
   }
 
+  const waterAmt = form.querySelector('[name="water_amount"]');
+  if (waterAmt && waterAmt.value) {
+    const v = parseFloat(waterAmt.value);
+    if (isNaN(v) || v < 0) {
+      document.getElementById('water_amount-error').textContent =
+        'Enter a positive number.';
+      valid = false;
+    }
+  }
+
   return valid;
 }
 
@@ -256,6 +266,7 @@ async function updatePlantInline(plant, field, newValue) {
   data.append('name', plant.name);
   data.append('species', plant.species);
   data.append('watering_frequency', plant.watering_frequency);
+  data.append('water_amount', plant.water_amount);
   data.append('fertilizing_frequency', plant.fertilizing_frequency);
   data.append('room', plant.room);
   data.append('last_watered', plant.last_watered || '');
@@ -282,6 +293,7 @@ async function updatePlantPhoto(plant, file) {
   data.append('name', plant.name);
   data.append('species', plant.species);
   data.append('watering_frequency', plant.watering_frequency);
+  data.append('water_amount', plant.water_amount);
   data.append('fertilizing_frequency', plant.fertilizing_frequency);
   data.append('room', plant.room);
   data.append('last_watered', plant.last_watered || '');
@@ -303,6 +315,7 @@ function populateForm(plant) {
   form.name.value = plant.name;
   form.species.value = plant.species;
   form.watering_frequency.value = plant.watering_frequency;
+  form.water_amount.value = plant.water_amount;
   form.fertilizing_frequency.value = plant.fertilizing_frequency;
   form.room.value = plant.room;
   form.last_watered.value = plant.last_watered;
@@ -438,6 +451,10 @@ async function loadPlants() {
     waterSpan.classList.add('summary-item');
     waterSpan.innerHTML = ICONS.water + ` ${plant.watering_frequency} days`;
     summary.appendChild(waterSpan);
+    const amountSpan = document.createElement("span");
+    amountSpan.classList.add("summary-item");
+    amountSpan.innerHTML = ICONS.water + ` ${plant.water_amount || 0} mL`;
+    summary.appendChild(amountSpan);
 
     const fertSpan = document.createElement('span');
     fertSpan.classList.add('summary-item');

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@
 
 --color-bg: #f1f8e9;
 
---color-surface: #fffff;
+--color-surface: #ffffff;
 
 --color-border: #c8e6c9; 
 

--- a/water_calculator.php
+++ b/water_calculator.php
@@ -1,0 +1,42 @@
+<?php
+$config = require __DIR__ . '/config.php';
+
+function fetchWeather($config) {
+    $url = 'https://api.openweathermap.org/data/2.5/weather?q=' . urlencode($config['location']) . '&appid=' . $config['openweather_key'];
+
+    $ctx = stream_context_create([
+        'http' => [
+            'timeout' => 10
+        ]
+    ]);
+    $json = @file_get_contents($url, false, $ctx);
+    if ($json === false) {
+        throw new RuntimeException('Failed to fetch weather data.');
+    }
+    $data = json_decode($json, true);
+    if ($data === null) {
+        throw new RuntimeException('Failed to decode weather data.');
+    }
+    return $data;
+}
+
+try {
+    $data = fetchWeather($config);
+    $tmin = $data['main']['temp_min'] - 273.15;
+    $tmax = $data['main']['temp_max'] - 273.15;
+    $tavg = ($tmin + $tmax) / 2;
+
+    $et0 = 0.0023 * ($tavg + 17.8) * sqrt(max(0, $tmax - $tmin)) * $config['ra'];
+    $etc = $config['kc'] * $et0;
+
+    $r = $config['pot_diameter_cm'] / 2;
+    $area = pi() * $r * $r;
+
+    $water_ml = $etc * $area * 0.1;
+
+    echo "Daily watering for {$config['location']}: " . round($water_ml) . " mL\n";
+} catch (Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+    exit(1);
+}
+?>


### PR DESCRIPTION
## Summary
- use env variables for DB connection
- fix stray text and duplicate Tailwind script
- correct CSS color
- add water amount support in form, JS, and API
- include sample `.env.example`
- create `config.php` and `water_calculator.php`

## Testing
- `phpunit --configuration phpunit.xml`
- `php water_calculator.php` *(fails: Failed to fetch weather data)*

------
https://chatgpt.com/codex/tasks/task_e_685b627cd8b08324b85baa5a0d1c3a02