### PR TITLE
Fix spacing for due-task buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -244,7 +244,8 @@ button:focus {
     padding: calc(var(--spacing) / 2) var(--spacing);
     border-radius: var(--radius);
     font-weight: bold;
-    margin-left: calc(var(--spacing) * 1.25);
+    /* spacing is handled by the actions grid gap */
+    margin: 0;
 }
 
 .water-due {


### PR DESCRIPTION
## Summary
- avoid margin pushing due action buttons out of grid

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685bdceb54848324bafe3f4355391722