### PR TITLE
Add water amount field

### DIFF
--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -26,6 +26,7 @@ $species = trim($_POST['species'] ?? '');
 $room = trim($_POST['room'] ?? '');
 $watering_frequency = intval($_POST['watering_frequency'] ?? 0);
 $fertilizing_frequency = intval($_POST['fertilizing_frequency'] ?? 0);
+$water_amount = isset($_POST['water_amount']) ? floatval($_POST['water_amount']) : 0;
 $last_watered = $_POST['last_watered'] ?? null;
 $last_fertilized = $_POST['last_fertilized'] ?? null;
 $photo_url = trim($_POST['photo_url'] ?? '');
@@ -40,6 +41,9 @@ if ($room !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,50}$/', $room)) {
 }
 if ($watering_frequency < 1 || $watering_frequency > 365) {
     $errors[] = 'Watering frequency must be 1-365';
+}
+if ($water_amount <= 0) {
+    $errors[] = 'Water amount must be positive';
 }
 if ($errors) {
     http_response_code(400);
@@ -74,8 +78,16 @@ if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
 $stmt = $conn->prepare(
     "
     INSERT INTO plants (
-        name, species, room, watering_frequency, fertilizing_frequency, last_watered, last_fertilized, photo_url
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+        name,
+        species,
+        room,
+        watering_frequency,
+        fertilizing_frequency,
+        last_watered,
+        last_fertilized,
+        photo_url,
+        water_amount
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
 );
 if (!$stmt) {
     @http_response_code(500);
@@ -86,7 +98,7 @@ if (!$stmt) {
     return;
 }
 $stmt->bind_param(
-    "sssiisss",
+    "sssiisssd",
     $name,
     $species,
     $room,
@@ -94,7 +106,8 @@ $stmt->bind_param(
     $fertilizing_frequency,
     $last_watered,
     $last_fertilized,
-    $photo_url
+    $photo_url,
+    $water_amount
 );
 
 if (!$stmt->execute()) {

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -14,7 +14,7 @@ if (!headers_sent()) {
 
 $plants = [];
 $result = $conn->query(
-    "SELECT id, name, species, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url
+    "SELECT id, name, species, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount
     FROM plants
     ORDER BY id DESC"
 );

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -17,6 +17,7 @@ $species                 = trim($_POST['species'] ?? '');
 $room                    = trim($_POST['room'] ?? '');
 $watering_frequency      = intval($_POST['watering_frequency'] ?? 0);
 $fertilizing_frequency   = intval($_POST['fertilizing_frequency'] ?? 0);
+$water_amount            = isset($_POST['water_amount']) ? floatval($_POST['water_amount']) : 0;
 $last_watered            = $_POST['last_watered'] ?: null;
 $last_fertilized         = $_POST['last_fertilized'] ?: null;
 $photo_url               = trim($_POST['photo_url'] ?? '');
@@ -31,6 +32,9 @@ if ($room !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,50}$/', $room)) {
 }
 if ($watering_frequency < 1 || $watering_frequency > 365) {
     $errors[] = 'Watering frequency must be 1-365';
+}
+if ($water_amount <= 0) {
+    $errors[] = 'Water amount must be positive';
 }
 
 if ($errors) {
@@ -61,7 +65,7 @@ if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
 
 // Basic validation
 
-if (!$id || $name === '' || $watering_frequency <= 0) {
+if (!$id || $name === '' || $watering_frequency <= 0 || $water_amount <= 0) {
     @http_response_code(400);
     echo json_encode(['error' => 'Missing or invalid fields']);
     exit;
@@ -77,11 +81,12 @@ $stmt = $conn->prepare("
         fertilizing_frequency = ?,
         last_watered       = ?,
         last_fertilized    = ?,
-        photo_url          = ?
+        photo_url          = ?,
+        water_amount       = ?
     WHERE id = ?
 ");
 $stmt->bind_param(
-    'sssiisssi',
+    'sssiisssdi',
     $name,
     $species,
     $room,
@@ -90,6 +95,7 @@ $stmt->bind_param(
     $last_watered,
     $last_fertilized,
     $photo_url,
+    $water_amount,
     $id
 );
 

--- a/index.html
+++ b/index.html
@@ -64,6 +64,10 @@
             <div class="error" id="watering_frequency-error"></div>
         </div>
         <div>
+            <label for="water_amount" class="block mb-1">Water Amount (ml)</label>
+            <input type="number" name="water_amount" id="water_amount" class="w-full border rounded-md p-2" />
+        </div>
+        <div>
             <label for="fertilizing_frequency" class="block mb-1">Fertilizing Frequency (days)</label>
             <input type="number" name="fertilizing_frequency" id="fertilizing_frequency" class="w-full border rounded-md p-2" />
         </div>

--- a/script.js
+++ b/script.js
@@ -275,6 +275,7 @@ async function updatePlantInline(plant, field, newValue) {
   data.append('species', plant.species);
   data.append('watering_frequency', plant.watering_frequency);
   data.append('fertilizing_frequency', plant.fertilizing_frequency);
+  data.append('water_amount', plant.water_amount);
   data.append('room', plant.room);
   data.append('last_watered', plant.last_watered || '');
   data.append('last_fertilized', plant.last_fertilized || '');
@@ -301,6 +302,7 @@ async function updatePlantPhoto(plant, file) {
   data.append('species', plant.species);
   data.append('watering_frequency', plant.watering_frequency);
   data.append('fertilizing_frequency', plant.fertilizing_frequency);
+  data.append('water_amount', plant.water_amount);
   data.append('room', plant.room);
   data.append('last_watered', plant.last_watered || '');
   data.append('last_fertilized', plant.last_fertilized || '');
@@ -321,6 +323,9 @@ function populateForm(plant) {
   form.name.value = plant.name;
   form.species.value = plant.species;
   form.watering_frequency.value = plant.watering_frequency;
+  if (form.water_amount) {
+    form.water_amount.value = plant.water_amount;
+  }
   form.fertilizing_frequency.value = plant.fertilizing_frequency;
   form.room.value = plant.room;
   form.last_watered.value = plant.last_watered;
@@ -335,6 +340,7 @@ function populateForm(plant) {
 function resetForm() {
   const form = document.getElementById('plant-form');
   form.reset();
+  if (form.water_amount) form.water_amount.value = '';
   editingPlantId = null;
   form.querySelector('button[type="submit"]').innerHTML = ICONS.plus + '<span class="visually-hidden">Add Plant</span>';
   document.getElementById('cancel-edit').style.display = 'none';
@@ -456,6 +462,13 @@ async function loadPlants() {
     waterSpan.classList.add('summary-item');
     waterSpan.innerHTML = ICONS.water + ` ${plant.watering_frequency} days`;
     summary.appendChild(waterSpan);
+
+    if (plant.water_amount) {
+      const amtSpan = document.createElement('span');
+      amtSpan.classList.add('summary-item');
+      amtSpan.textContent = `${plant.water_amount} ml`;
+      summary.appendChild(amtSpan);
+    }
 
     const fertSpan = document.createElement('span');
     fertSpan.classList.add('summary-item');
@@ -618,6 +631,7 @@ document.addEventListener('DOMContentLoaded',()=>{
     e.preventDefault(); const form=e.target;
     if (!validateForm(form)) return;
     const data=new FormData(form);
+    data.set('water_amount', form.water_amount ? form.water_amount.value : '');
     const btn=form.querySelector('button[type="submit"]');
     btn.disabled=true;
     btn.innerHTML=(editingPlantId?ICONS.check:ICONS.plus)+

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -31,5 +31,36 @@ class ApiTest extends TestCase
         $this->assertFalse($data['success']);
         $this->assertArrayHasKey('error', $data);
     }
+
+    public function testAddPlantWithWaterAmount()
+    {
+        $_POST = [
+            'name' => 'Test Plant',
+            'watering_frequency' => 5,
+            'water_amount' => 100
+        ];
+        ob_start();
+        include __DIR__ . '/../api/add_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('success', $data['status']);
+    }
+
+    public function testUpdatePlantWithWaterAmount()
+    {
+        $_POST = [
+            'id' => 1,
+            'name' => 'Updated',
+            'watering_frequency' => 7,
+            'water_amount' => 150,
+            'last_watered' => '',
+            'last_fertilized' => ''
+        ];
+        ob_start();
+        include __DIR__ . '/../api/update_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('success', $data['status']);
+    }
 }
 ?>


### PR DESCRIPTION
## Summary
- track `water_amount` for plants
- read and validate the new field in API endpoints
- expose the field through `get_plants.php`
- add input for water amount in the form and handle it in the UI
- display water amount on plant cards
- update PHPUnit tests for the new field

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685be40b270c8324b8540c06cccd4abb