### PR TITLE
Add water amount formatter

### DIFF
--- a/script.js
+++ b/script.js
@@ -29,6 +29,11 @@ function parseWaterAmount(value) {
   return amt;
 }
 
+function formatWaterAmount(ml) {
+  const ounces = ml / ML_PER_US_FL_OUNCE;
+  return `${ounces.toFixed(1)}oz (${ml.toFixed(2)} ml)`;
+}
+
 const ICONS = {
   trash: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>',
   water: '<svg class="icon icon-water" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z"/></svg>',
@@ -488,7 +493,7 @@ async function loadPlants() {
     if (plant.water_amount) {
       const amtSpan = document.createElement('span');
       amtSpan.classList.add('summary-item');
-      amtSpan.textContent = `${plant.water_amount} ml`;
+      amtSpan.textContent = formatWaterAmount(parseFloat(plant.water_amount));
       summary.appendChild(amtSpan);
     }
 


### PR DESCRIPTION
## Summary
- add formatWaterAmount helper in `script.js`
- display formatted water amount on plant cards

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685bf58a2bac8324948396c425592a78