### PR TITLE
Add blue styles for water tags

### DIFF
--- a/style.css
+++ b/style.css
@@ -503,6 +503,17 @@ button:focus {
   font-weight: 600;
 }
 
+/* water amount tags use the blue palette */
+.oz-tag {
+  background-color: var(--color-water);
+  color: var(--color-surface);
+}
+
+.ml-tag {
+  background-color: var(--color-water-bg);
+  color: var(--color-water-hover);
+}
+
 /* tag showing the plant's room - color is set inline via JS */
 .room-tag {}
 


### PR DESCRIPTION
## Summary
- use the water color palette for water amount tags

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c0de49e6483248cfe2fcc9b9514ac