### PR TITLE
Adjust room tag colors for white text

### DIFF
--- a/script.js
+++ b/script.js
@@ -15,7 +15,8 @@ function colorForRoom(room) {
       hash = room.charCodeAt(i) + ((hash << 5) - hash);
     }
     const hue = Math.abs(hash) % 360;
-    roomColors[room] = `hsl(${hue}, 60%, 80%)`;
+    // use a darker lightness so the white tag text stays readable
+    roomColors[room] = `hsl(${hue}, 60%, 45%)`;
   }
   return roomColors[room];
 }


### PR DESCRIPTION
## Summary
- darken dynamically generated room tag colors so white text remains readable

## Testing
- `phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_685c0e1d5c708324abbebb87ab35ce98