### PR TITLE
Validate delete ID param

### DIFF
--- a/api/delete_plant.php
+++ b/api/delete_plant.php
@@ -11,10 +11,11 @@ if (!headers_sent()) {
 }
 
 $id = $_POST['id'] ?? null;
+$id = filter_var($id, FILTER_VALIDATE_INT);
 
-if (!$id) {
+if ($id === false || $id <= 0) {
     @http_response_code(400);
-    echo json_encode(['success' => false, 'error' => 'No ID provided']);
+    echo json_encode(['success' => false, 'error' => 'Invalid plant ID']);
     return;
 }
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -32,6 +32,17 @@ class ApiTest extends TestCase
         $this->assertArrayHasKey('error', $data);
     }
 
+    public function testDeletePlantInvalidId()
+    {
+        $_POST = ['id' => 'abc'];
+        ob_start();
+        include __DIR__ . '/../api/delete_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertFalse($data['success']);
+        $this->assertArrayHasKey('error', $data);
+    }
+
     public function testAddPlantWithWaterAmount()
     {
         $_POST = [


### PR DESCRIPTION
## Summary
- validate delete ID using `filter_var`
- test invalid delete ID

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c130e3f8c8324aedf4ea7c1874402