### PR TITLE
Add 404 handling for missing plant updates

### DIFF
--- a/api/mark_fertilized.php
+++ b/api/mark_fertilized.php
@@ -39,6 +39,14 @@ if (!$stmt->execute()) {
     echo json_encode(['status' => 'error', 'error' => 'Database error', 'details' => $stmt->error]);
     return;
 }
+
+if ($stmt->affected_rows === 0) {
+    $stmt->close();
+    @http_response_code(404);
+    echo json_encode(['status' => 'error', 'error' => 'Plant not found']);
+    return;
+}
+
 $stmt->close();
 
 @http_response_code(200);

--- a/api/mark_watered.php
+++ b/api/mark_watered.php
@@ -39,6 +39,14 @@ if (!$stmt->execute()) {
     echo json_encode(['status' => 'error', 'error' => 'Database error', 'details' => $stmt->error]);
     return;
 }
+
+if ($stmt->affected_rows === 0) {
+    $stmt->close();
+    @http_response_code(404);
+    echo json_encode(['status' => 'error', 'error' => 'Plant not found']);
+    return;
+}
+
 $stmt->close();
 
 @http_response_code(200);


### PR DESCRIPTION
## Summary
- mark watering and fertilizing endpoints return 404 when no rows updated

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c131db7ec8324b5627d2e96f7f8dc