### PR TITLE
Add snooze dropdowns for plant tasks

### DIFF
--- a/script.js
+++ b/script.js
@@ -550,6 +550,27 @@ async function loadPlants() {
       btn.title = 'Mark watered';
       btn.onclick = () => markAction(plant.id, 'watered');
       actionsDiv.appendChild(btn);
+
+      const snooze = document.createElement('select');
+      snooze.classList.add('snooze-select');
+      const placeholder = document.createElement('option');
+      placeholder.textContent = 'Snooze';
+      placeholder.selected = true;
+      placeholder.disabled = true;
+      snooze.appendChild(placeholder);
+      [1, 2, 3].forEach(d => {
+        const opt = document.createElement('option');
+        opt.value = d;
+        opt.textContent = `${d} day${d > 1 ? 's' : ''}`;
+        snooze.appendChild(opt);
+      });
+      snooze.onchange = () => {
+        if (snooze.value) {
+          markAction(plant.id, 'watered', parseInt(snooze.value));
+          snooze.selectedIndex = 0;
+        }
+      };
+      actionsDiv.appendChild(snooze);
     }
 
     if (fertDue) {
@@ -559,6 +580,27 @@ async function loadPlants() {
       btn.title = 'Mark fertilized';
       btn.onclick = () => markAction(plant.id, 'fertilized');
       actionsDiv.appendChild(btn);
+
+      const snooze = document.createElement('select');
+      snooze.classList.add('snooze-select');
+      const placeholder = document.createElement('option');
+      placeholder.textContent = 'Snooze';
+      placeholder.selected = true;
+      placeholder.disabled = true;
+      snooze.appendChild(placeholder);
+      [1, 2, 3].forEach(d => {
+        const opt = document.createElement('option');
+        opt.value = d;
+        opt.textContent = `${d} day${d > 1 ? 's' : ''}`;
+        snooze.appendChild(opt);
+      });
+      snooze.onchange = () => {
+        if (snooze.value) {
+          markAction(plant.id, 'fertilized', parseInt(snooze.value));
+          snooze.selectedIndex = 0;
+        }
+      };
+      actionsDiv.appendChild(snooze);
     }
 
     const editBtn = document.createElement('button');

--- a/style.css
+++ b/style.css
@@ -455,6 +455,17 @@ button:focus {
   width: 100%;
 }
 
+/* small dropdown for snoozing tasks */
+.snooze-select {
+  width: 100%;
+  height: 2.25rem;
+  padding: calc(var(--spacing) / 2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-bg);
+  font-size: 0.85rem;
+}
+
 .plant-card .plant-photo {
   width: 100%;
   height: 150px;


### PR DESCRIPTION
## Summary
- add `.snooze-select` style for small dropdowns next to due-task buttons
- allow snoozing watering or fertilizing by 1–3 days in `script.js`

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c1667fa2483249767888b29dfd043