### PR TITLE
Remove Snooze text from dropdown

### DIFF
--- a/script.js
+++ b/script.js
@@ -602,7 +602,7 @@ async function loadPlants() {
       const snooze = document.createElement('select');
       snooze.classList.add('snooze-select');
       const placeholder = document.createElement('option');
-      placeholder.textContent = 'Snooze';
+      placeholder.textContent = '';
       placeholder.selected = true;
       placeholder.disabled = true;
       snooze.appendChild(placeholder);
@@ -632,7 +632,7 @@ async function loadPlants() {
       const snooze = document.createElement('select');
       snooze.classList.add('snooze-select');
       const placeholder = document.createElement('option');
-      placeholder.textContent = 'Snooze';
+      placeholder.textContent = '';
       placeholder.selected = true;
       placeholder.disabled = true;
       snooze.appendChild(placeholder);


### PR DESCRIPTION
## Summary
- cleanup snooze select so only the icon shows

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c25a3171c8324bd64b872b6c78269