### PR TITLE
Fix snooze dropdown icon centering

### DIFF
--- a/style.css
+++ b/style.css
@@ -479,9 +479,9 @@ button:focus {
   font-size: 0.85rem;
   background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSIjMmUzYTI5IiBzdHJva2Utd2lkdGg9IjIiIHN0cm9rZS1saW5lY2FwPSJyb3VuZCIgc3Ryb2tlLWxpbmVqb2luPSJyb3VuZCI+PGNpcmNsZSBjeD0iMTIiIGN5PSIxMiIgcj0iMTAiLz48cG9seWxpbmUgcG9pbnRzPSIxMiA2IDEyIDEyIDE2IDE0Ii8+PC9zdmc+");
   background-repeat: no-repeat;
-  background-position: 8px center;
+  background-position: center;
   background-size: 1rem 1rem;
-  padding-left: calc(var(--spacing) * 2 + 1rem);
+  padding-left: 0;
   cursor: pointer;
   transition: background-color 0.2s, transform 0.1s;
 }


### PR DESCRIPTION
## Summary
- style `.snooze-select` with centered background icon

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c2c0a0d088324a0a927c2fd14bead