### PR TITLE
Adjust card image style

### DIFF
--- a/style.css
+++ b/style.css
@@ -455,6 +455,7 @@ button:focus {
   padding: calc(var(--spacing) * 2);
   display: flex;
   flex-direction: column;
+  overflow: hidden; /* clip photo when it extends to edges */
 }
 
 .plant-card .actions {
@@ -497,11 +498,13 @@ button:focus {
 }
 
 .plant-card .plant-photo {
-  width: 100%;
+  width: calc(100% + (var(--spacing) * 4));
   height: 150px;
   object-fit: cover;
-  border-radius: 12px;
-  margin-bottom: calc(var(--spacing) * 1.5);
+  display: block;
+  margin: calc(var(--spacing) * -2) calc(var(--spacing) * -2)
+          calc(var(--spacing) * 1.5);
+  border-radius: 0;
 }
 
 .plant-card.due-overdue {


### PR DESCRIPTION
## Summary
- make `plant-card` overflow hidden to clip image at edges
- allow `plant-photo` to extend into padding area so it sits flush with the card border

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c456c12e88324a0acddf1398d04aa