### PR TITLE
Add border to water amount tags

### DIFF
--- a/style.css
+++ b/style.css
@@ -548,11 +548,13 @@ button:focus {
 .oz-tag {
   background-color: var(--color-water-bg);
   color: var(--color-water-hover);
+  border: 1px solid var(--color-water);
 }
 
 .ml-tag {
   background-color: var(--color-water-bg);
   color: var(--color-water-hover);
+  border: 1px solid var(--color-water);
 }
 
 /* tag showing the plant's room - color is set inline via JS */


### PR DESCRIPTION
## Summary
- add a visible border to `.oz-tag` and `.ml-tag` for better readability

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c45bcbc4483248a10b849dffbe12c