### PR TITLE
Add border styling to room tags

### DIFF
--- a/script.js
+++ b/script.js
@@ -21,6 +21,17 @@ function colorForRoom(room) {
   return roomColors[room];
 }
 
+function borderColorForRoom(room) {
+  if (!room) return 'var(--color-accent)';
+  let hash = 0;
+  for (let i = 0; i < room.length; i++) {
+    hash = room.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const hue = Math.abs(hash) % 360;
+  // slightly darker than the fill color
+  return `hsl(${hue}, 60%, 35%)`;
+}
+
 function parseWaterAmount(value) {
   let amt = parseFloat(value);
   if (isNaN(amt)) return NaN;
@@ -521,6 +532,7 @@ async function loadPlants() {
       roomTag.classList.add('tag', 'room-tag');
       roomTag.textContent = plant.room;
       roomTag.style.backgroundColor = colorForRoom(plant.room);
+      roomTag.style.borderColor = borderColorForRoom(plant.room);
       tagList.appendChild(roomTag);
     }
     if (plant.water_amount) {

--- a/style.css
+++ b/style.css
@@ -561,7 +561,9 @@ button:focus {
 }
 
 /* tag showing the plant's room - color is set inline via JS */
-.room-tag {}
+.room-tag {
+  border: 1px solid transparent;
+}
 
 .plant-summary {
   display: grid;


### PR DESCRIPTION
## Summary
- generate a border color per room
- apply border color when rendering room tag
- give `.room-tag` a default 1px border

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c49a77f448324b8e841fb49235222