### PR TITLE
Round top corners of photos

### DIFF
--- a/style.css
+++ b/style.css
@@ -504,7 +504,10 @@ button:focus {
   display: block;
   margin: calc(var(--spacing) * -2) calc(var(--spacing) * -2)
           calc(var(--spacing) * 1.5);
-  border-radius: 0;
+  /* match card radius so top corners align while bottom stays flush */
+  border-radius: inherit;
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
 }
 
 .plant-card.due-overdue {


### PR DESCRIPTION
## Summary
- round off photo corners within plant cards by inheriting the card radius

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4b3cd0148324b83b5d2c5b2da2d8