### PR TITLE
Improve calendar event visuals

### DIFF
--- a/script.js
+++ b/script.js
@@ -278,8 +278,9 @@ async function loadCalendar() {
     const dayEl = container.querySelector(`.cal-day[data-date="${dateStr}"]`);
     if (!dayEl) return;
     const ev = document.createElement('div');
-    ev.classList.add('cal-event', type==='water' ? 'water-due' : 'fert-due');
-    ev.textContent = `${plant.name} (${type==='water'? 'Water':'Fert'})`;
+    ev.classList.add('cal-event', type === 'water' ? 'water-due' : 'fert-due');
+    ev.innerHTML =
+      (type === 'water' ? ICONS.water : ICONS.fert) + ' ' + plant.name;
     ev.draggable = true;
     ev.dataset.id = plant.id;
     ev.dataset.type = type;

--- a/style.css
+++ b/style.css
@@ -428,6 +428,16 @@ button:focus {
   box-shadow: 0 1px 2px rgba(0,0,0,0.1);
 }
 
+#calendar .cal-event.water-due {
+  background-color: var(--color-water-bg);
+  color: var(--color-water);
+}
+
+#calendar .cal-event.fert-due {
+  background-color: var(--color-sprout-bg);
+  color: var(--color-plant);
+}
+
 /* card layout */
 #plant-grid {
   display: grid;


### PR DESCRIPTION
## Summary
- colorize calendar events using theme palette
- add watering and fertilizing icons to calendar events

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c532a08e48324be027d2f3910a01a