### PR TITLE
Add calendar week navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,7 +122,12 @@
 
     <div id="plant-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 p-4"></div>
 
-    <h3 class="text-xl font-semibold p-4">Upcoming Tasks</h3>
+    <h3 class="text-xl font-semibold p-4 flex items-center">Upcoming Tasks
+        <span class="ml-auto flex gap-2">
+            <button id="prev-week" class="bg-primary text-white rounded-md px-4 py-2">Prev</button>
+            <button id="next-week" class="bg-primary text-white rounded-md px-4 py-2">Next</button>
+        </span>
+    </h3>
     <div id="calendar" class="p-4"></div>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -13,6 +13,10 @@ const WEATHER_API_KEY = '2aa3ade8428368a141f7951420570c16';
 // number of milliliters in one US fluid ounce
 const ML_PER_US_FL_OUNCE = 29.5735;
 
+// starting date for the calendar view
+let calendarStartDate = new Date();
+calendarStartDate.setHours(0, 0, 0, 0);
+
 // map room names to generated colors so tags remain consistent
 const roomColors = {};
 function colorForRoom(room) {
@@ -256,7 +260,7 @@ async function loadCalendar() {
   const container = document.getElementById('calendar');
   if (!container) return;
   const daysToShow = 7;
-  const start = new Date();
+  const start = new Date(calendarStartDate);
   start.setHours(0,0,0,0);
   container.innerHTML = '';
 
@@ -808,6 +812,8 @@ document.addEventListener('DOMContentLoaded',()=>{
   const roomFilter = document.getElementById('room-filter');
   const sortToggle = document.getElementById('sort-toggle');
   const dueFilterEl = document.getElementById('due-filter');
+  const prevBtn = document.getElementById('prev-week');
+  const nextBtn = document.getElementById('next-week');
 
   // apply saved preferences before initial load
   loadFilterPrefs();
@@ -903,6 +909,18 @@ document.addEventListener('DOMContentLoaded',()=>{
     dueFilterEl.addEventListener('change', () => {
       saveFilterPrefs();
       loadPlants();
+    });
+  }
+  if (prevBtn) {
+    prevBtn.addEventListener('click', () => {
+      calendarStartDate = addDays(calendarStartDate, -7);
+      loadCalendar();
+    });
+  }
+  if (nextBtn) {
+    nextBtn.addEventListener('click', () => {
+      calendarStartDate = addDays(calendarStartDate, 7);
+      loadCalendar();
     });
   }
   loadPlants();


### PR DESCRIPTION
## Summary
- add Prev/Next buttons for the calendar
- track a `calendarStartDate` variable
- navigate weeks via new buttons

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685c5331ecf48324bae064848a49cd36