### PR TITLE
Use Tailwind shadow utility on plant cards

### DIFF
--- a/script.js
+++ b/script.js
@@ -575,7 +575,7 @@ async function loadPlants() {
 
   filtered.forEach(plant => {
     const card = document.createElement('div');
-    card.classList.add('plant-card');
+    card.classList.add('plant-card', 'shadow');
     if (plant.id === window.lastUpdatedPlantId) {
       card.classList.add('just-updated');
       setTimeout(() => card.classList.remove('just-updated'), 2000);

--- a/style.css
+++ b/style.css
@@ -458,7 +458,6 @@ button:focus {
 .plant-card {
   background: #ffffff;
   border-radius: 12px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   padding: calc(var(--spacing) * 2);
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- remove custom `box-shadow` from `.plant-card`
- apply Tailwind `shadow` class when creating plant cards

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c6015b3d08324ba773c400c88f3e8