### PR TITLE
Add lazy loading for plant photos

### DIFF
--- a/script.js
+++ b/script.js
@@ -593,6 +593,7 @@ async function loadPlants() {
       const img = document.createElement('img');
       img.src = plant.photo_url;
       img.alt = plant.name;
+      img.loading = 'lazy';
       img.classList.add('plant-photo');
       card.appendChild(img);
     }


### PR DESCRIPTION
## Summary
- enable browser lazy loading on plant photo elements to defer off-screen images

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c78f1f8cc8324a503881020a0a3e8