### PR TITLE
Add heatmap overview of upcoming tasks

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,8 @@
 
     <div id="plant-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 p-4"></div>
 
+    <div id="heatmap" class="p-4"></div>
+
     <h3 class="text-xl font-semibold p-4 flex items-center">Upcoming Tasks
         <span class="ml-auto flex gap-2">
             <button id="prev-week" class="bg-primary text-white rounded-md px-4 py-2">Prev</button>

--- a/script.js
+++ b/script.js
@@ -301,6 +301,38 @@ async function loadCalendar() {
     const f = getNextFertDate(p);
     if (f) addEvent(p,'fert',f);
   });
+
+  loadHeatmap(plants);
+}
+
+async function loadHeatmap(plantsData) {
+  const plants = plantsData || (await (await fetch('api/get_plants.php')).json());
+  const container = document.getElementById('heatmap');
+  if (!container) return;
+  const days = 28;
+  const start = new Date();
+  start.setHours(0,0,0,0);
+  const counts = new Array(days).fill(0);
+  plants.forEach(p => {
+    const w = getNextWaterDate(p);
+    let diff = Math.floor((w - start) / 86400000);
+    if (diff >= 0 && diff < days) counts[diff]++;
+    const f = getNextFertDate(p);
+    if (f) {
+      diff = Math.floor((f - start) / 86400000);
+      if (diff >= 0 && diff < days) counts[diff]++;
+    }
+  });
+  container.innerHTML = '';
+  for (let i=0;i<days;i++) {
+    const cell = document.createElement('div');
+    cell.classList.add('heat-cell');
+    const level = counts[i] >= 3 ? 3 : counts[i];
+    cell.classList.add(`level-${level}`);
+    const date = addDays(start,i);
+    cell.title = `${date.toLocaleDateString()} - ${counts[i]} task${counts[i]!==1?'s':''}`;
+    container.appendChild(cell);
+  }
 }
 
 async function handleDrop(e,newDate,plants) {

--- a/style.css
+++ b/style.css
@@ -422,6 +422,27 @@ button:focus {
   color: var(--color-plant);
 }
 
+/* small heatmap to show upcoming task counts */
+#heatmap {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 4px;
+  max-width: 200px;
+  margin: calc(var(--spacing) * 2) auto;
+}
+
+#heatmap .heat-cell {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+  background: var(--color-border);
+}
+
+#heatmap .level-0 { background: var(--color-border); }
+#heatmap .level-1 { background: #c6f6d5; }
+#heatmap .level-2 { background: #68d391; }
+#heatmap .level-3 { background: #38a169; }
+
 /* card layout */
 #plant-grid {
   display: grid;


### PR DESCRIPTION
## Summary
- add small heatmap grid above Upcoming Tasks
- style heatmap cells and intensity levels
- generate 4‑week heatmap in JS

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685c78d9606c8324a086d6617653fa5c