### PR TITLE
Hide calendar until heatmap click

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,13 +125,13 @@
 
     <div id="heatmap" class="p-4"></div>
 
-    <h3 class="text-xl font-semibold p-4 flex items-center">Upcoming Tasks
+    <h3 id="calendar-heading" class="text-xl font-semibold p-4 flex items-center hidden">Upcoming Tasks
         <span class="ml-auto flex gap-2">
             <button id="prev-week" class="bg-primary text-white rounded-md px-4 py-2">Prev</button>
             <button id="next-week" class="bg-primary text-white rounded-md px-4 py-2">Next</button>
         </span>
     </h3>
-    <div id="calendar" class="p-4"></div>
+    <div id="calendar" class="p-4 hidden"></div>
 
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -854,9 +854,24 @@ document.addEventListener('DOMContentLoaded',()=>{
   const dueFilterEl = document.getElementById('due-filter');
   const prevBtn = document.getElementById('prev-week');
   const nextBtn = document.getElementById('next-week');
+  const heatmap = document.getElementById('heatmap');
+  const calendarEl = document.getElementById('calendar');
+  const calendarHeading = document.getElementById('calendar-heading');
 
   // apply saved preferences before initial load
   loadFilterPrefs();
+
+  if (calendarEl) calendarEl.classList.add('hidden');
+  if (calendarHeading) calendarHeading.classList.add('hidden');
+  if (heatmap) {
+    const showCalendar = () => {
+      if (calendarEl) calendarEl.classList.remove('hidden');
+      if (calendarHeading) calendarHeading.classList.remove('hidden');
+      loadCalendar();
+    };
+    heatmap.addEventListener('click', showCalendar, { once: true });
+    heatmap.addEventListener('touchstart', showCalendar, { once: true });
+  }
 
   if (showBtn) {
     showBtn.innerHTML = ICONS.plus + '<span class="visually-hidden">Add a Plant</span>';
@@ -964,6 +979,6 @@ document.addEventListener('DOMContentLoaded',()=>{
     });
   }
   loadPlants();
-  loadCalendar();
+  loadHeatmap();
   fetchWeather();
 });


### PR DESCRIPTION
## Summary
- default calendar section hidden in the markup
- add logic to show the calendar when the heatmap is touched/clicked
- load heatmap on page load; load calendar only after interaction

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c851f4a4483248a3bc22c04738b6d