### PR TITLE
Restyle heatmap like GitHub

### DIFF
--- a/style.css
+++ b/style.css
@@ -452,23 +452,26 @@ button:focus {
 /* small heatmap to show upcoming task counts */
 #heatmap {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 4px;
-  max-width: 200px;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(7, 1fr);
+  grid-auto-columns: 10px;
+  gap: 3px;
+  max-width: fit-content;
   margin: calc(var(--spacing) * 2) auto;
 }
 
 #heatmap .heat-cell {
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   border-radius: 2px;
-  background: var(--color-border);
+  background: #ebedf0;
+  cursor: pointer;
 }
 
-#heatmap .level-0 { background: var(--color-border); }
-#heatmap .level-1 { background: #c6f6d5; }
-#heatmap .level-2 { background: #68d391; }
-#heatmap .level-3 { background: #38a169; }
+#heatmap .level-0 { background: #ebedf0; }
+#heatmap .level-1 { background: #9be9a8; }
+#heatmap .level-2 { background: #40c463; }
+#heatmap .level-3 { background: #30a14e; }
 
 /* card layout */
 #plant-grid {


### PR DESCRIPTION
## Summary
- tweak the heatmap layout and colors to look closer to GitHub's contribution graph

## Testing
- `phpunit --configuration phpunit.xml` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ca67cde388324a5b211822c61c59b