### PR TITLE
Allow decimal water amounts

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
             </div>
             <div>
                 <label for="water_amount" class="block mb-1">Water Amount (oz)</label>
-                <input type="number" name="water_amount" id="water_amount" class="w-full border rounded-md p-2" />
+                <input type="number" name="water_amount" id="water_amount" step="0.1" class="w-full border rounded-md p-2" />
                 <p class="helper">Enter ounces of water</p>
                 <div class="error" id="water_amount-error"></div>
             </div>

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -57,6 +57,20 @@ class ApiTest extends TestCase
         $this->assertEquals('success', $data['status']);
     }
 
+    public function testAddPlantWithDecimalWaterAmount()
+    {
+        $_POST = [
+            'name' => 'Decimal Plant',
+            'watering_frequency' => 5,
+            'water_amount' => 123.45
+        ];
+        ob_start();
+        include __DIR__ . '/../api/add_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('success', $data['status']);
+    }
+
     public function testUpdatePlantWithWaterAmount()
     {
         $_POST = [


### PR DESCRIPTION
## Summary
- enable decimal entry for water amounts
- test adding a plant with a decimal water amount

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685cb5869b088324871ccd251b8989e9