### PR TITLE
Remove calendar close button

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,6 @@
         <span class="ml-auto flex gap-2">
             <button id="prev-week" class="bg-primary text-white rounded-md px-4 py-2">Prev</button>
             <button id="next-week" class="bg-primary text-white rounded-md px-4 py-2">Next</button>
-            <button id="close-calendar" type="button" class="bg-gray-200 rounded-md px-3 py-2"></button>
         </span>
     </h3>
     <div id="calendar" class="p-4 hidden"></div>

--- a/script.js
+++ b/script.js
@@ -899,7 +899,6 @@ document.addEventListener('DOMContentLoaded',()=>{
   const dueFilterEl = document.getElementById('due-filter');
   const prevBtn = document.getElementById('prev-week');
   const nextBtn = document.getElementById('next-week');
-  const closeCal = document.getElementById('close-calendar');
 
   const heatmap = document.getElementById('heatmap');
   const calendarEl = document.getElementById('calendar');
@@ -962,19 +961,6 @@ document.addEventListener('DOMContentLoaded',()=>{
       document.getElementById('search-input').value = '';
       loadPlants();
     });
-  }
-  if (closeCal) {
-    closeCal.innerHTML = ICONS.cancel + '<span class="visually-hidden">Close Calendar</span>';
-    const hideCalendar = () => {
-      if (calendarEl) calendarEl.classList.add('hidden');
-      if (calendarHeading) calendarHeading.classList.add('hidden');
-      if (heatmap) {
-        heatmap.addEventListener('click', showCalendar, { once: true });
-        heatmap.addEventListener('touchstart', showCalendar, { once: true });
-      }
-    };
-    closeCal.addEventListener('click', hideCalendar);
-    closeCal.addEventListener('touchstart', hideCalendar);
   }
   if (submitBtn) {
     submitBtn.innerHTML = ICONS.plus + '<span class="visually-hidden">Add Plant</span>';


### PR DESCRIPTION
## Summary
- remove the `close-calendar` button from the UI
- drop all JS handling for closing/hiding the calendar

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685cbbe57d2c832488f2e31f17828e72