### PR TITLE
Add overlay tags for plant urgency

### DIFF
--- a/script.js
+++ b/script.js
@@ -654,13 +654,26 @@ async function loadPlants() {
       setTimeout(() => card.classList.remove('just-updated'), 2000);
     }
     const soonest = getSoonestDueDate(plant);
+    let urgencyClass = '';
+    let urgencyText = '';
     if (soonest < startOfToday) {
       card.classList.add('due-overdue');
+      urgencyClass = 'urgency-overdue';
+      urgencyText = 'Overdue';
     } else if (soonest < startOfTomorrow) {
       card.classList.add('due-today');
+      urgencyClass = 'urgency-today';
+      urgencyText = 'Due Today';
     } else {
       card.classList.add('due-future');
+      urgencyClass = 'urgency-future';
+      urgencyText = 'Upcoming';
     }
+
+    const urgencyTag = document.createElement('span');
+    urgencyTag.classList.add('urgency-tag', urgencyClass);
+    urgencyTag.textContent = urgencyText;
+    card.appendChild(urgencyTag);
 
     const img = document.createElement('img');
     img.src = plant.photo_url || 'https://jonosmond.com/plant-tracker/placeholder.png';

--- a/style.css
+++ b/style.css
@@ -511,6 +511,7 @@ button:focus {
   display: flex;
   flex-direction: column;
   overflow: hidden; /* clip photo when it extends to edges */
+  position: relative; /* allow urgency tag overlay */
 }
 
 .plant-card .actions {
@@ -568,14 +569,10 @@ button:focus {
   }
 }
 
-.plant-card.due-overdue {
-  background-color: var(--color-error-bg);
-}
-.plant-card.due-today {
-  background-color: var(--color-warning-bg);
-}
+.plant-card.due-overdue,
+.plant-card.due-today,
 .plant-card.due-future {
-  background-color: #ffffff;
+  background-color: #ffffff; /* urgency shown via overlay tag instead */
 }
 
 .plant-title {
@@ -715,6 +712,30 @@ button:focus {
   color: var(--color-error);
   font-weight: bold;
   margin-bottom: var(--spacing);
+}
+
+/* urgency tag overlaid on the plant photo */
+.urgency-tag {
+  position: absolute;
+  top: calc(var(--spacing) * 2);
+  left: calc(var(--spacing) * 2);
+  padding: 2px 6px;
+  border-radius: var(--radius);
+  font-size: 0.75rem;
+  font-weight: 600;
+  z-index: 5;
+  color: var(--color-surface);
+}
+
+.urgency-overdue {
+  background-color: var(--color-error);
+}
+.urgency-today {
+  background-color: var(--color-warning);
+  color: var(--color-text);
+}
+.urgency-future {
+  background-color: var(--color-success);
 }
 
 


### PR DESCRIPTION
## Summary
- position plant cards to allow overlayed elements
- replace background urgency indicators with overlay tags
- keep plant cards white and display colored urgency banner over photos

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685cbca036c88324836955d0a62a64ca