### PR TITLE
Enable calendar always visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,13 +135,13 @@
 
     <div id="heatmap" class="p-4"></div>
 
-    <h3 id="calendar-heading" class="text-xl font-semibold p-4 flex items-center hidden">Upcoming Tasks
+    <h3 id="calendar-heading" class="text-xl font-semibold p-4 flex items-center">Upcoming Tasks
         <span class="ml-auto flex gap-2">
             <button id="prev-week" class="bg-primary text-white rounded-md px-4 py-2">Prev</button>
             <button id="next-week" class="bg-primary text-white rounded-md px-4 py-2">Next</button>
         </span>
     </h3>
-    <div id="calendar" class="p-4 hidden"></div>
+    <div id="calendar" class="p-4"></div>
 
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -900,10 +900,8 @@ document.addEventListener('DOMContentLoaded',()=>{
   const prevBtn = document.getElementById('prev-week');
   const nextBtn = document.getElementById('next-week');
 
-  const heatmap = document.getElementById('heatmap');
   const calendarEl = document.getElementById('calendar');
   const calendarHeading = document.getElementById('calendar-heading');
-  let showCalendar;
 
   const nextStepBtn = document.getElementById('next-step');
   const prevStepBtn = document.getElementById('prev-step');
@@ -917,17 +915,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   loadFilterPrefs();
   showFormStep(1);
 
-  if (calendarEl) calendarEl.classList.add('hidden');
-  if (calendarHeading) calendarHeading.classList.add('hidden');
-  if (heatmap) {
-    showCalendar = () => {
-      if (calendarEl) calendarEl.classList.remove('hidden');
-      if (calendarHeading) calendarHeading.classList.remove('hidden');
-      loadCalendar();
-    };
-    heatmap.addEventListener('click', showCalendar, { once: true });
-    heatmap.addEventListener('touchstart', showCalendar, { once: true });
-  }
+  loadCalendar();
 
   if (showBtn) {
     showBtn.innerHTML = ICONS.plus + '<span class="visually-hidden">Add a Plant</span>';


### PR DESCRIPTION
## Summary
- show calendar and heading by default in the main page
- remove heatmap click handler and load the calendar when the page initializes

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685cbd9deb1c8324b1cff9f7d26bb780