### PR TITLE
Improve inline update error message

### DIFF
--- a/script.js
+++ b/script.js
@@ -435,7 +435,12 @@ async function updatePlantInline(plant, field, newValue) {
     body: data
   });
   if (!resp.ok) {
-    showToast('Failed to save change', true);
+    let msg = 'Failed to save change';
+    try {
+      const err = await resp.json();
+      if (err && err.error) msg = err.error;
+    } catch (e) {}
+    showToast(msg, true);
   } else {
     loadPlants();
     loadCalendar();


### PR DESCRIPTION
## Summary
- parse API response in `updatePlantInline` to show errors from backend

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685cbf2ad7c88324b8257fcd65df4c79