### PR TITLE
Improve plant card grouping

### DIFF
--- a/script.js
+++ b/script.js
@@ -724,11 +724,30 @@ async function loadPlants() {
     const summary = document.createElement('div');
     summary.classList.add('plant-summary');
 
+    const waterGroup = document.createElement('div');
+    waterGroup.classList.add('summary-group');
+
     const waterSpan = document.createElement('span');
     waterSpan.classList.add('summary-item');
     waterSpan.innerHTML =
       ICONS.water + ` water every ${plant.watering_frequency} days`;
-    summary.appendChild(waterSpan);
+    waterGroup.appendChild(waterSpan);
+
+    const nextWaterSpan = document.createElement('span');
+    nextWaterSpan.classList.add('summary-item');
+    nextWaterSpan.innerHTML =
+      ICONS.water +
+      ` next watering is ${formatDateShort(getNextWaterDate(plant))}`;
+    waterGroup.appendChild(nextWaterSpan);
+
+    const lastWaterSpan = document.createElement('span');
+    lastWaterSpan.classList.add('summary-item');
+    lastWaterSpan.innerHTML =
+      ICONS.water + ` last watered ${formatDateShort(plant.last_watered)}`;
+    waterGroup.appendChild(lastWaterSpan);
+
+    const fertGroup = document.createElement('div');
+    fertGroup.classList.add('summary-group');
 
     const fertSpan = document.createElement('span');
     fertSpan.classList.add('summary-item');
@@ -736,14 +755,7 @@ async function loadPlants() {
       ? `${plant.fertilizing_frequency} days`
       : 'N/A';
     fertSpan.innerHTML = ICONS.fert + ` fertilize every ${fertFreq}`;
-    summary.appendChild(fertSpan);
-
-    const nextWaterSpan = document.createElement('span');
-    nextWaterSpan.classList.add('summary-item');
-    nextWaterSpan.innerHTML =
-      ICONS.water +
-      ` next watering is ${formatDateShort(getNextWaterDate(plant))}`;
-    summary.appendChild(nextWaterSpan);
+    fertGroup.appendChild(fertSpan);
 
     const nextFertSpan = document.createElement('span');
     nextFertSpan.classList.add('summary-item');
@@ -751,20 +763,16 @@ async function loadPlants() {
     nextFertSpan.innerHTML =
       ICONS.fert +
       ` next fertilizing is ${nextFert ? formatDateShort(nextFert) : 'N/A'}`;
-    summary.appendChild(nextFertSpan);
-
-    const lastWaterSpan = document.createElement('span');
-    lastWaterSpan.classList.add('summary-item');
-    lastWaterSpan.innerHTML =
-      ICONS.water + ` last watered ${formatDateShort(plant.last_watered)}`;
-    summary.appendChild(lastWaterSpan);
-
+    fertGroup.appendChild(nextFertSpan);
 
     const lastFertSpan = document.createElement('span');
     lastFertSpan.classList.add('summary-item');
     lastFertSpan.innerHTML =
       ICONS.fert + ` last fertilized ${formatDateShort(plant.last_fertilized)}`;
-    summary.appendChild(lastFertSpan);
+    fertGroup.appendChild(lastFertSpan);
+
+    summary.appendChild(waterGroup);
+    summary.appendChild(fertGroup);
 
     card.appendChild(summary);
 

--- a/style.css
+++ b/style.css
@@ -624,10 +624,9 @@ button:focus {
 }
 
 .plant-summary {
-  display: grid;
-  grid-template-columns: repeat(2, auto);
-  column-gap: calc(var(--spacing));
-  row-gap: calc(var(--spacing));
+  display: flex;
+  flex-direction: column;
+  gap: calc(var(--spacing) * 0.75);
   font-size: var(--font-size-sm);
   margin-bottom: calc(var(--spacing));
   text-transform: capitalize;
@@ -650,6 +649,20 @@ button:focus {
   flex-direction: column;
   align-items: flex-start;
   line-height: 1.2;
+}
+
+/* grouped summary sections */
+.summary-group {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  column-gap: calc(var(--spacing));
+  row-gap: calc(var(--spacing));
+}
+
+.summary-group + .summary-group {
+  margin-top: calc(var(--spacing));
+  padding-top: calc(var(--spacing) / 2);
+  border-top: 1px solid var(--color-border);
 }
 
 .plant-summary .water-amount .ml-line {


### PR DESCRIPTION
## Summary
- group water and fertilizer info in plant cards
- add subtle dividers between info groups

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685cc2d3d8d0832483fd2e51d02e1db9