### PR TITLE
Add cache busting to script.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,14 +143,10 @@
     </h3>
     <div id="calendar" class="p-4"></div>
 
-<<<<<<< edk4u1-codex/ensure-users-get-latest-js-version
-    <script src="script.js"></script>
-=======
     <script>
       const script = document.createElement('script');
       script.src = 'script.js?v=' + Date.now();
       document.body.appendChild(script);
     </script>
->>>>>>> main
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove leftover merge markers from `index.html`
- dynamically load `script.js` with a timestamp to avoid cached versions

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685d581803c88324a4d4d506ba0e480c