### PR TITLE
Add login system with session checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,16 @@ Plant Tracker is a lightweight PHP and JavaScript application for keeping tabs o
    ```bash
    mysql -u <user> -p <database> < migrations/001_add_water_amount.sql
    mysql -u <user> -p <database> < migrations/002_add_water_amount.sql
+   mysql -u <user> -p <database> < migrations/003_create_users.sql
    ```
    The first script adds the column if it does not exist. The second modifies it to DECIMAL(8,2) for consistent precision.
-4. Launch a local development server:
+4. Create a user account:
+   Generate a password hash and insert it into the `users` table:
+   ```bash
+   php -r "echo password_hash('yourpass', PASSWORD_DEFAULT);"
+   mysql -u <user> -p <database> -e "INSERT INTO users (username, password_hash) VALUES ('admin', '<hash>')"
+   ```
+5. Launch a local development server:
    ```bash
    php -S localhost:8000
    ```
@@ -62,3 +69,5 @@ If you want to use the weather lookup feature, edit `script.js` and replace the 
 Once the migration is applied, each plant entry includes a `water_amount` value that indicates how much water it typically receives. Enter the amount in fluid ounces and the UI shows the equivalent in milliliters. The value is stored in milliliters so you can work in either unit as needed.
 
 Uploaded photos are placed in the `uploads` directory. When a plant is updated with a new image or removed entirely, the previous photo is moved to `uploads/archive/` rather than deleted. If a name collision occurs, a timestamp is appended so the older file is preserved.
+
+Before adding or updating plants you must log in using the form at the top of the page. The credentials correspond to an entry in the `users` table created during setup.

--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -3,7 +3,19 @@ $dbConfig = getenv('DB_CONFIG');
 if ($dbConfig && file_exists($dbConfig)) {
     include $dbConfig;
 } else {
-    include '../db.php';
+include '../db.php';
+}
+
+if (session_status() === PHP_SESSION_NONE) {
+    @session_start();
+}
+if (!isset($_SESSION['user_id'])) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    return;
 }
 
 if (!headers_sent()) {
@@ -122,4 +134,3 @@ $stmt->close();
 
 @http_response_code(201);
 echo json_encode(['status' => 'success']);
-?>

--- a/api/delete_plant.php
+++ b/api/delete_plant.php
@@ -3,7 +3,19 @@ $dbConfig = getenv('DB_CONFIG');
 if ($dbConfig && file_exists($dbConfig)) {
     include $dbConfig;
 } else {
-    include('../db.php');
+include('../db.php');
+}
+
+if (session_status() === PHP_SESSION_NONE) {
+    @session_start();
+}
+if (!isset($_SESSION['user_id'])) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    return;
 }
 
 if (!headers_sent()) {
@@ -62,4 +74,3 @@ if ($stmt->affected_rows > 0) {
     @http_response_code(404);
     echo json_encode(['success' => false, 'error' => 'Plant not found']);
 }
-?>

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -29,4 +29,3 @@ while ($row = $result->fetch_assoc()) {
 }
 
 echo json_encode($plants);
-?>

--- a/api/login.php
+++ b/api/login.php
@@ -1,0 +1,50 @@
+<?php
+$dbConfig = getenv('DB_CONFIG');
+if ($dbConfig && file_exists($dbConfig)) {
+    include $dbConfig;
+} else {
+    include '../db.php';
+}
+
+if (session_status() === PHP_SESSION_NONE) {
+    @session_start();
+}
+if (!headers_sent()) {
+    header('Content-Type: application/json');
+}
+
+$username = trim($_POST['username'] ?? '');
+$password = $_POST['password'] ?? '';
+
+if ($username === '' || $password === '') {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing credentials']);
+    return;
+}
+
+$stmt = $conn->prepare('SELECT id, password_hash FROM users WHERE username = ?');
+if (!$stmt) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database error', 'details' => $conn->error]);
+    return;
+}
+$stmt->bind_param('s', $username);
+if (!$stmt->execute()) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database error', 'details' => $stmt->error]);
+    return;
+}
+$result = $stmt->get_result();
+$user = $result ? $result->fetch_assoc() : null;
+$stmt->close();
+
+if (!$user || !password_verify($password, $user['password_hash'])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Invalid credentials']);
+    return;
+}
+
+$_SESSION['user_id'] = $user['id'];
+http_response_code(200);
+
+echo json_encode(['status' => 'success', 'user_id' => $user['id']]);

--- a/api/mark_fertilized.php
+++ b/api/mark_fertilized.php
@@ -5,7 +5,19 @@ $dbConfig = getenv('DB_CONFIG');
 if ($dbConfig && file_exists($dbConfig)) {
     include $dbConfig;
 } else {
-    include '../db.php';
+include '../db.php';
+}
+
+if (session_status() === PHP_SESSION_NONE) {
+    @session_start();
+}
+if (!isset($_SESSION['user_id'])) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    return;
 }
 
 if (!headers_sent()) {
@@ -52,4 +64,3 @@ $stmt->close();
 @http_response_code(200);
 
 echo json_encode(['status' => 'success', 'updated' => $today]);
-?>

--- a/api/mark_watered.php
+++ b/api/mark_watered.php
@@ -5,7 +5,19 @@ $dbConfig = getenv('DB_CONFIG');
 if ($dbConfig && file_exists($dbConfig)) {
     include $dbConfig;
 } else {
-    include '../db.php';
+include '../db.php';
+}
+
+if (session_status() === PHP_SESSION_NONE) {
+    @session_start();
+}
+if (!isset($_SESSION['user_id'])) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    return;
 }
 
 if (!headers_sent()) {
@@ -52,4 +64,3 @@ $stmt->close();
 @http_response_code(200);
 
 echo json_encode(['status' => 'success', 'updated' => $today]);
-?>

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -3,7 +3,19 @@ $dbConfig = getenv('DB_CONFIG');
 if ($dbConfig && file_exists($dbConfig)) {
     include $dbConfig;
 } else {
-    include '../db.php';
+include '../db.php';
+}
+
+if (session_status() === PHP_SESSION_NONE) {
+    @session_start();
+}
+if (!isset($_SESSION['user_id'])) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    return;
 }
 
 if (!headers_sent()) {

--- a/db.php
+++ b/db.php
@@ -1,12 +1,10 @@
 <?php
-$host = "localhost"; // Leave this as is
-$user = "u568785491_jon"; // Your actual DB user
-$pass = "yS+olgrwgD1";  // ✅ Your new password
-$dbname = "u568785491_plants"; // Your actual DB name
+$host = getenv('DB_HOST') ?: 'localhost';
+$user = getenv('DB_USER');
+$pass = getenv('DB_PASS');
+$dbname = getenv('DB_NAME');
 
 $conn = new mysqli($host, $user, $pass, $dbname);
-
 if ($conn->connect_error) {
-    die("Connection failed: " . $conn->connect_error);
+    die('Connection failed: ' . $conn->connect_error);
 }
-?>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,19 @@
     <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
 </head>
 <body class="bg-bg text-text min-h-screen">
+    <form id="login-form" class="p-4 bg-card rounded-lg shadow max-w-sm mx-auto mt-6">
+        <div class="mb-2">
+            <label for="login-username" class="block mb-1">Username</label>
+            <input type="text" id="login-username" name="username" class="w-full border rounded-md p-2" />
+        </div>
+        <div class="mb-2">
+            <label for="login-password" class="block mb-1">Password</label>
+            <input type="password" id="login-password" name="password" class="w-full border rounded-md p-2" />
+        </div>
+        <div id="login-error" class="error mb-2"></div>
+        <button type="submit" class="bg-primary text-white rounded-md px-4 py-2 w-full">Login</button>
+    </form>
+    <div id="app-container" class="hidden">
     <h1 class="app-title text font-bold px-4 py-0">
         <img id="title-weather-icon" class="title-icon" alt="" style="display:none;">
         My Plant Tracker
@@ -143,6 +156,7 @@
         </span>
     </h2>
     <div id="calendar" class="p-4"></div>
+    </div> <!-- end app-container -->
 
     <script>
       const script = document.createElement('script');

--- a/migrations/003_create_users.sql
+++ b/migrations/003_create_users.sql
@@ -1,0 +1,6 @@
+-- Create users table for login system
+CREATE TABLE IF NOT EXISTS users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(100) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL
+);

--- a/script.js
+++ b/script.js
@@ -926,6 +926,24 @@ async function loadPlants() {
 
 // --- init ---
 function init(){
+  const loginForm = document.getElementById('login-form');
+  const appContainer = document.getElementById('app-container');
+  if (loginForm) {
+    loginForm.addEventListener('submit', async e => {
+      e.preventDefault();
+      const data = new FormData(loginForm);
+      const resp = await fetch('api/login.php', { method: 'POST', body: data, credentials: 'same-origin' });
+      if (resp.ok) {
+        loginForm.style.display = 'none';
+        if (appContainer) appContainer.classList.remove('hidden');
+        loadPlants();
+        loadCalendar();
+      } else {
+        const out = await resp.json().catch(() => ({}));
+        document.getElementById('login-error').textContent = out.error || 'Login failed';
+      }
+    });
+  }
   const showBtn = document.getElementById('show-add-form');
   const exportBtn = document.getElementById('export-json');
   const form = document.getElementById('plant-form');

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -9,6 +9,12 @@ class ApiTest extends TestCase
         $this->dbConfig = __DIR__ . '/db_stub.php';
         putenv('DB_CONFIG=' . $this->dbConfig);
         putenv('TESTING=1');
+        $_SESSION = ['user_id' => 1];
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
     }
 
     public function testAddPlantMissingName()

--- a/tests/db_stub.php
+++ b/tests/db_stub.php
@@ -17,4 +17,3 @@ if (!class_exists('MockMysqli')) {
 }
 
 $conn = new MockMysqli();
-?>


### PR DESCRIPTION
## Summary
- introduce user authentication and `login.php`
- enforce logged-in sessions for write operations
- add `users` table migration
- source DB credentials from environment variables
- include login form on the UI
- update README instructions and tests

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685d9079abe88324ba042678deb04035