### PR TITLE
Wrap debug error reporting

### DIFF
--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -1,6 +1,8 @@
 <?php
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
+if (getenv('DEBUG')) {
+    ini_set('display_errors', 1);
+    error_reporting(E_ALL);
+}
 $dbConfig = getenv('DB_CONFIG');
 if ($dbConfig && file_exists($dbConfig)) {
     include $dbConfig;

--- a/api/mark_fertilized.php
+++ b/api/mark_fertilized.php
@@ -1,6 +1,8 @@
 <?php
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
+if (getenv('DEBUG')) {
+    ini_set('display_errors', 1);
+    error_reporting(E_ALL);
+}
 $dbConfig = getenv('DB_CONFIG');
 if ($dbConfig && file_exists($dbConfig)) {
     include $dbConfig;

--- a/api/mark_watered.php
+++ b/api/mark_watered.php
@@ -1,6 +1,8 @@
 <?php
-ini_set('display_errors', 1);
-error_reporting(E_ALL);
+if (getenv('DEBUG')) {
+    ini_set('display_errors', 1);
+    error_reporting(E_ALL);
+}
 $dbConfig = getenv('DB_CONFIG');
 if ($dbConfig && file_exists($dbConfig)) {
     include $dbConfig;


### PR DESCRIPTION
## Summary
- guard `ini_set`/`error_reporting` in API endpoints with a DEBUG env var

## Testing
- `phpunit --configuration phpunit.xml`
- `php -r 'chdir("api"); putenv("DB_CONFIG=../tests/db_stub.php"); $_POST=["id"=>0]; include "mark_watered.php";'`
- `php -r 'chdir("api"); putenv("DB_CONFIG=../tests/db_stub.php"); $_POST=["id"=>0]; include "mark_fertilized.php";'`

------
https://chatgpt.com/codex/tasks/task_e_685dbb45ae68832490511a16080e5f46