### PR TITLE
Hide DB errors unless DEBUG

### DIFF
--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -6,6 +6,12 @@ if ($dbConfig && file_exists($dbConfig)) {
     include '../db.php';
 }
 
+$debug = getenv('DEBUG');
+if ($debug) {
+    ini_set('display_errors', 1);
+    error_reporting(E_ALL);
+}
+
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }
@@ -91,7 +97,11 @@ $stmt = $conn->prepare(
 );
 if (!$stmt) {
     @http_response_code(500);
-    echo json_encode(['error' => 'Database error', 'details' => $conn->error]);
+    $response = ['error' => 'Database error'];
+    if ($debug) {
+        $response['details'] = $conn->error;
+    }
+    echo json_encode($response);
     if (!getenv('TESTING')) {
         exit;
     }
@@ -112,7 +122,11 @@ $stmt->bind_param(
 
 if (!$stmt->execute()) {
     @http_response_code(500);
-    echo json_encode(['error' => 'Database error', 'details' => $stmt->error]);
+    $response = ['error' => 'Database error'];
+    if ($debug) {
+        $response['details'] = $stmt->error;
+    }
+    echo json_encode($response);
     if (!getenv('TESTING')) {
         exit;
     }

--- a/api/delete_plant.php
+++ b/api/delete_plant.php
@@ -6,6 +6,12 @@ if ($dbConfig && file_exists($dbConfig)) {
     include('../db.php');
 }
 
+$debug = getenv('DEBUG');
+if ($debug) {
+    ini_set('display_errors', 1);
+    error_reporting(E_ALL);
+}
+
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }
@@ -23,13 +29,21 @@ if ($id === false || $id <= 0) {
 $stmt = $conn->prepare("DELETE FROM plants WHERE id = ?");
 if (!$stmt) {
     @http_response_code(500);
-    echo json_encode(['success' => false, 'error' => 'Database error', 'details' => $conn->error]);
+    $response = ['success' => false, 'error' => 'Database error'];
+    if ($debug) {
+        $response['details'] = $conn->error;
+    }
+    echo json_encode($response);
     return;
 }
 $stmt->bind_param("i", $id);
 if (!$stmt->execute()) {
     @http_response_code(500);
-    echo json_encode(['success' => false, 'error' => 'Database error', 'details' => $stmt->error]);
+    $response = ['success' => false, 'error' => 'Database error'];
+    if ($debug) {
+        $response['details'] = $stmt->error;
+    }
+    echo json_encode($response);
     return;
 }
 

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -1,5 +1,6 @@
 <?php
-if (getenv('DEBUG')) {
+$debug = getenv('DEBUG');
+if ($debug) {
     ini_set('display_errors', 1);
     error_reporting(E_ALL);
 }
@@ -22,7 +23,11 @@ $result = $conn->query(
 );
 if (!$result) {
     @http_response_code(500);
-    echo json_encode(['error' => 'Database error', 'details' => $conn->error]);
+    $response = ['error' => 'Database error'];
+    if ($debug) {
+        $response['details'] = $conn->error;
+    }
+    echo json_encode($response);
     return;
 }
 

--- a/api/mark_fertilized.php
+++ b/api/mark_fertilized.php
@@ -1,5 +1,6 @@
 <?php
-if (getenv('DEBUG')) {
+$debug = getenv('DEBUG');
+if ($debug) {
     ini_set('display_errors', 1);
     error_reporting(E_ALL);
 }
@@ -32,13 +33,21 @@ $today = $date->format('Y-m-d');
 $stmt = $conn->prepare("UPDATE plants SET last_fertilized = ? WHERE id = ?");
 if (!$stmt) {
     @http_response_code(500);
-    echo json_encode(['status' => 'error', 'error' => 'Database error', 'details' => $conn->error]);
+    $response = ['status' => 'error', 'error' => 'Database error'];
+    if ($debug) {
+        $response['details'] = $conn->error;
+    }
+    echo json_encode($response);
     return;
 }
 $stmt->bind_param("si", $today, $id);
 if (!$stmt->execute()) {
     @http_response_code(500);
-    echo json_encode(['status' => 'error', 'error' => 'Database error', 'details' => $stmt->error]);
+    $response = ['status' => 'error', 'error' => 'Database error'];
+    if ($debug) {
+        $response['details'] = $stmt->error;
+    }
+    echo json_encode($response);
     return;
 }
 

--- a/api/mark_watered.php
+++ b/api/mark_watered.php
@@ -1,5 +1,6 @@
 <?php
-if (getenv('DEBUG')) {
+$debug = getenv('DEBUG');
+if ($debug) {
     ini_set('display_errors', 1);
     error_reporting(E_ALL);
 }
@@ -32,13 +33,21 @@ $today = $date->format('Y-m-d');
 $stmt = $conn->prepare("UPDATE plants SET last_watered = ? WHERE id = ?");
 if (!$stmt) {
     @http_response_code(500);
-    echo json_encode(['status' => 'error', 'error' => 'Database error', 'details' => $conn->error]);
+    $response = ['status' => 'error', 'error' => 'Database error'];
+    if ($debug) {
+        $response['details'] = $conn->error;
+    }
+    echo json_encode($response);
     return;
 }
 $stmt->bind_param("si", $today, $id);
 if (!$stmt->execute()) {
     @http_response_code(500);
-    echo json_encode(['status' => 'error', 'error' => 'Database error', 'details' => $stmt->error]);
+    $response = ['status' => 'error', 'error' => 'Database error'];
+    if ($debug) {
+        $response['details'] = $stmt->error;
+    }
+    echo json_encode($response);
     return;
 }
 

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -6,6 +6,12 @@ if ($dbConfig && file_exists($dbConfig)) {
     include '../db.php';
 }
 
+$debug = getenv('DEBUG');
+if ($debug) {
+    ini_set('display_errors', 1);
+    error_reporting(E_ALL);
+}
+
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }
@@ -124,7 +130,11 @@ $stmt->bind_param(
 
 if (!$stmt->execute()) {
     @http_response_code(500);
-    echo json_encode(['error' => 'Database error', 'details' => $stmt->error]);
+    $response = ['error' => 'Database error'];
+    if ($debug) {
+        $response['details'] = $stmt->error;
+    }
+    echo json_encode($response);
     exit;
 }
 

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -1,0 +1,31 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ErrorHandlingTest extends TestCase
+{
+    private $dbConfig;
+
+    protected function setUp(): void
+    {
+        $this->dbConfig = __DIR__ . '/db_stub_fail.php';
+        putenv('DB_CONFIG=' . $this->dbConfig);
+        putenv('TESTING=1');
+        putenv('DEBUG'); // ensure DEBUG is unset
+    }
+
+    public function testDatabaseErrorHidesDetailsWhenDebugDisabled()
+    {
+        $_POST = [
+            'name' => 'Fail Plant',
+            'watering_frequency' => 5,
+            'water_amount' => 100
+        ];
+        ob_start();
+        include __DIR__ . '/../api/add_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('Database error', $data['error']);
+        $this->assertArrayNotHasKey('details', $data);
+    }
+}
+?>

--- a/tests/db_stub_fail.php
+++ b/tests/db_stub_fail.php
@@ -1,0 +1,10 @@
+<?php
+class FailMysqli {
+    public $error = 'Simulated DB error';
+    public function prepare($query) {
+        return false; // simulate failure
+    }
+}
+
+$conn = new FailMysqli();
+?>


### PR DESCRIPTION
## Summary
- ensure API endpoints only output DB details when DEBUG is enabled
- create failing DB stub and test that details stay hidden without DEBUG

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685dc1fea3c483248c84c1f4474bf68e