### PR TITLE
Add runtime weather API key config

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ Set the following environment variables so `db.php` can establish the database c
 
 `db.php` reads these values using `getenv`. Alternatively you can set `DB_CONFIG` to the path of a PHP file that defines `$host`, `$user`, `$pass` and `$dbname`. Ensure these variables are available in your environment (or defined in a `.env` file loaded by your web server) before running the application so credentials are not stored in the codebase.
 
-If you want to use the weather lookup feature, edit `script.js` and replace the `WEATHER_API_KEY` constant with your own OpenWeather API key.
+To use the optional weather lookup feature, provide your OpenWeather API key at runtime.
+Add a meta tag such as `<meta name="weather-api-key" content="YOUR_KEY">` to
+`index.html` or set `window.WEATHER_API_KEY` before `script.js` loads. The
+script reads the value from either location so deployments can supply the key
+without modifying the source files.
 
 ## Usage
 

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- Optional: provide your OpenWeather API key here -->
+    <meta name="weather-api-key" content="">
     <title>Plant Tracker</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/script.js
+++ b/script.js
@@ -9,8 +9,11 @@ let currentWeather = null;
 let currentWeatherIcon = null;
 let currentWeatherDesc = null;
 
-// public OpenWeather API key provided by user
-const WEATHER_API_KEY = '2aa3ade8428368a141f7951420570c16';
+// runtime OpenWeather API key (from meta tag or window variable)
+function getWeatherApiKey() {
+  const meta = document.querySelector('meta[name="weather-api-key"]');
+  return (meta && meta.content) || window.WEATHER_API_KEY || '';
+}
 
 // number of milliliters in one US fluid ounce
 const ML_PER_US_FL_OUNCE = 29.5735;
@@ -487,7 +490,9 @@ function fetchWeather() {
 
   const fetchByCoords = async (lat, lon) => {
     try {
-      const res = await fetch(`https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&units=imperial&appid=${WEATHER_API_KEY}`);
+      const apiKey = getWeatherApiKey();
+      if (!apiKey) return;
+      const res = await fetch(`https://api.openweathermap.org/data/2.5/weather?lat=${lat}&lon=${lon}&units=imperial&appid=${apiKey}`);
       if (!res.ok) return;
       const data = await res.json();
       addWeather(Math.round(data.main.temp), data.weather[0].main, data.weather[0].icon);


### PR DESCRIPTION
## Summary
- read OpenWeather API key from a `weather-api-key` meta tag or `window.WEATHER_API_KEY`
- provide placeholder meta tag in `index.html`
- document new runtime configuration in README

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685dc1f572508324adbd1e85b50cc290