### PR TITLE
Fix photo removal on plant update

### DIFF
--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -29,6 +29,21 @@ $last_watered            = $_POST['last_watered'] ?? null;
 $last_fertilized         = $_POST['last_fertilized'] ?? null;
 $photo_url               = trim($_POST['photo_url'] ?? '');
 
+// If no new photo or URL is provided, retain the existing one
+if ($photo_url === '' && (!isset($_FILES['photo']) || $_FILES['photo']['error'] !== UPLOAD_ERR_OK)) {
+    $stmt = $conn->prepare("SELECT photo_url FROM plants WHERE id = ?");
+    if ($stmt) {
+        $stmt->bind_param('i', $id);
+        if ($stmt->execute()) {
+            $stmt->bind_result($existingUrl);
+            if ($stmt->fetch()) {
+                $photo_url = $existingUrl;
+            }
+        }
+        $stmt->close();
+    }
+}
+
 // further validation
 $errors = [];
 if ($species !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,100}$/', $species)) {

--- a/tests/db_stub.php
+++ b/tests/db_stub.php
@@ -2,7 +2,9 @@
 if (!class_exists('MockStmt')) {
     class MockStmt {
         public function bind_param(...$args) {}
+        public function bind_result(&...$args) {}
         public function execute() { return true; }
+        public function fetch() { return false; }
         public function close() {}
     }
 }


### PR DESCRIPTION
## Summary
- preserve existing photo when updating plant info if no new file is uploaded
- extend test database stub with `bind_result`/`fetch`

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685de4cf4ae08324ab421baead170581