### PR TITLE
Fix dropdown text color

### DIFF
--- a/style.css
+++ b/style.css
@@ -804,4 +804,17 @@ button:focus {
   to { transform: rotate(360deg); }
 }
 
+/* Ensure pot diameter unit dropdown text is readable */
+#pot_diameter_unit {
+  color: var(--color-text);
+}
+
+/* Restrict plant form width so inputs aren't overly wide */
+#plant-form {
+  width: 100%;
+  max-width: 700px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 


### PR DESCRIPTION
## Summary
- ensure pot diameter unit select text is legible by using the main text color
- keep plant form from stretching too wide on large screens

## Testing
- `phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_685e020408d48324913db658448d0899