### PR TITLE
Add wilting animation for water warning overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -744,9 +744,29 @@ button:focus {
 }
 
 .water-warning {
+  position: absolute;
+  top: 120px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 4px 8px;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: var(--radius);
   color: var(--color-error);
   font-weight: bold;
-  margin-bottom: var(--spacing);
+  z-index: 10;
+  animation: wilt 1.5s ease-in-out infinite alternate;
+  pointer-events: none;
+}
+
+@keyframes wilt {
+  0% {
+    transform: translateX(-50%) translateY(0) rotate(0deg) scale(1);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(-50%) translateY(10px) rotate(10deg) scale(0.9);
+    opacity: 0.8;
+  }
 }
 
 /* urgency tag overlaid on the plant photo */


### PR DESCRIPTION
## Summary
- overlay `water-warning` text on plant images
- add `wilt` keyframes animation so the warning text droops over time

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685e087f21e883248b458afdfe1c7952