### PR TITLE
Reorganize plant form layout

### DIFF
--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -49,8 +49,8 @@ if ($room !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,50}$/', $room)) {
 if ($watering_frequency < 1 || $watering_frequency > 365) {
     $errors[] = 'Watering frequency must be 1-365';
 }
-if ($water_amount <= 0) {
-    $errors[] = 'Water amount must be positive';
+if ($water_amount < 0) {
+    $errors[] = 'Water amount must be non-negative';
 }
 if ($errors) {
     http_response_code(400);

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -55,8 +55,8 @@ if ($room !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,50}$/', $room)) {
 if ($watering_frequency < 1 || $watering_frequency > 365) {
     $errors[] = 'Watering frequency must be 1-365';
 }
-if ($water_amount <= 0) {
-    $errors[] = 'Water amount must be positive';
+if ($water_amount < 0) {
+    $errors[] = 'Water amount must be non-negative';
 }
 
 if ($errors) {
@@ -111,7 +111,7 @@ if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
 
 // Basic validation
 
-if (!$id || $name === '' || $watering_frequency <= 0 || $water_amount <= 0) {
+if (!$id || $name === '' || $watering_frequency <= 0 || $water_amount < 0) {
     @http_response_code(400);
     echo json_encode(['error' => 'Missing or invalid fields']);
     exit;

--- a/index.html
+++ b/index.html
@@ -48,50 +48,33 @@
     </div>
 
 
-    <form id="plant-form" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 p-4 bg-card rounded-lg shadow hidden" enctype="multipart/form-data">
+    <form id="plant-form" class="flex flex-col gap-6 p-4 bg-card rounded-lg shadow hidden" enctype="multipart/form-data">
 
+        <fieldset class="flex flex-col gap-4">
+            <legend class="font-semibold">Plant Identity</legend>
             <div>
                 <label for="name" class="block mb-1">Plant Name</label>
                 <input type="text" name="name" id="name" placeholder="Plant Name" class="w-full border rounded-md p-2" />
                 <div class="error" id="name-error"></div>
             </div>
             <div>
-                <label for="species" class="block mb-1">Species</label>
-                <input type="text" name="species" id="species" placeholder="Species" class="w-full border rounded-md p-2" />
-                <div class="error" id="species-error"></div>
-            </div>
-            <div>
-                <label for="room" class="block mb-1">Room</label>
-                <input type="text" name="room" id="room" placeholder="Room" class="w-full border rounded-md p-2" />
-                <div class="error" id="room-error"></div>
-            </div>
-            <div>
                 <label for="photo" class="block mb-1">Upload Photo</label>
                 <div id="photo-drop" class="photo-drop-zone">Drop image or click to upload</div>
                 <input type="file" id="photo" name="photo" accept="image/*" class="hidden" />
             </div>
+            <div>
+                <label for="species" class="block mb-1">Species</label>
+                <input type="text" name="species" id="species" placeholder="Species" class="w-full border rounded-md p-2" />
+                <div class="error" id="species-error"></div>
+            </div>
+        </fieldset>
 
+        <fieldset class="flex flex-col gap-4">
+            <legend class="font-semibold">Location &amp; Classification</legend>
             <div>
-                <label for="watering_frequency" class="block mb-1">Watering Frequency (days)</label>
-                <input type="number" name="watering_frequency" id="watering_frequency" class="w-full border rounded-md p-2" />
-                <p class="helper">Days between waterings, e.g. 7 for weekly</p>
-                <div class="error" id="watering_frequency-error"></div>
-            </div>
-            <div>
-                <label for="water_amount" class="block mb-1">Water Amount (oz)</label>
-                <input type="number" name="water_amount" id="water_amount" step="0.1" class="w-full border rounded-md p-2" />
-                <p class="helper">Enter ounces of water or leave blank to auto-calculate</p>
-                <div class="error" id="water_amount-error"></div>
-            </div>
-            <div>
-                <label for="pot_diameter" class="block mb-1">Pot Diameter</label>
-                <div class="flex gap-2">
-                    <input type="number" id="pot_diameter" step="0.1" class="w-full border rounded-md p-2" />
-                    <select id="pot_diameter_unit" class="border rounded-md p-2">
-                        <option value="cm">cm</option>
-                        <option value="in">in</option>
-                    </select>
-                </div>
+                <label for="room" class="block mb-1">Room</label>
+                <input type="text" name="room" id="room" placeholder="Room" class="w-full border rounded-md p-2" />
+                <div class="error" id="room-error"></div>
             </div>
             <div>
                 <label for="plant_type" class="block mb-1">Plant Type</label>
@@ -102,10 +85,44 @@
                     <option value="cacti">Cacti</option>
                 </select>
             </div>
+        </fieldset>
+
+        <fieldset class="flex flex-col gap-4">
+            <legend class="font-semibold">Pot Details</legend>
+            <div>
+                <label for="pot_diameter" class="block mb-1">Pot Diameter</label>
+                <div class="flex gap-2">
+                    <input type="number" id="pot_diameter" step="0.1" class="w-full border rounded-md p-2" />
+                    <select id="pot_diameter_unit" class="border rounded-md p-2">
+                        <option value="cm">cm</option>
+                        <option value="in">in</option>
+                    </select>
+                </div>
+            </div>
+        </fieldset>
+
+        <fieldset class="flex flex-col gap-4">
+            <legend class="font-semibold">Care Schedule</legend>
+            <div>
+                <label for="water_amount" class="block mb-1">Water Amount (oz)</label>
+                <input type="number" name="water_amount" id="water_amount" step="0.1" class="w-full border rounded-md p-2" />
+                <p class="helper">Enter ounces of water or leave blank to auto-calculate</p>
+                <div class="error" id="water_amount-error"></div>
+            </div>
+            <div>
+                <label for="watering_frequency" class="block mb-1">Watering Frequency (days)</label>
+                <input type="number" name="watering_frequency" id="watering_frequency" class="w-full border rounded-md p-2" />
+                <p class="helper">Days between waterings, e.g. 7 for weekly</p>
+                <div class="error" id="watering_frequency-error"></div>
+            </div>
             <div>
                 <label for="fertilizing_frequency" class="block mb-1">Fertilizing Frequency (days)</label>
                 <input type="number" name="fertilizing_frequency" id="fertilizing_frequency" class="w-full border rounded-md p-2" />
             </div>
+        </fieldset>
+
+        <fieldset class="flex flex-col gap-4">
+            <legend class="font-semibold">History &amp; Tracking</legend>
             <div>
                 <label for="last_watered" class="block mb-1">Last Watered</label>
                 <input type="date" name="last_watered" id="last_watered" class="w-full border rounded-md p-2" />
@@ -114,8 +131,9 @@
                 <label for="last_fertilized" class="block mb-1">Last Fertilized</label>
                 <input type="date" name="last_fertilized" id="last_fertilized" class="w-full border rounded-md p-2" />
             </div>
+        </fieldset>
 
-        <div class="sm:col-span-2 flex gap-2 justify-end mt-4">
+        <div class="flex gap-2 justify-end mt-4">
             <button type="button" id="cancel-edit" class="bg-gray-200 rounded-md px-4 py-2 hidden"></button>
             <button type="submit" id="submit-btn" class="bg-primary text-white rounded-md px-4 py-2"></button>
         </div>

--- a/script.js
+++ b/script.js
@@ -221,11 +221,14 @@ function validateForm(form) {
 
   const waterAmtField = form.water_amount;
   if (waterAmtField) {
-    const amt = parseWaterAmount(waterAmtField.value);
-    if (waterAmtField.value.trim() === '' || isNaN(amt) || amt <= 0) {
-      const errorDiv = document.getElementById('water_amount-error');
-      if (errorDiv) errorDiv.textContent = 'Enter a positive number.';
-      valid = false;
+    const val = waterAmtField.value.trim();
+    if (val !== '') {
+      const amt = parseWaterAmount(val);
+      if (isNaN(amt) || amt <= 0) {
+        const errorDiv = document.getElementById('water_amount-error');
+        if (errorDiv) errorDiv.textContent = 'Enter a positive number.';
+        valid = false;
+      }
     }
   }
 
@@ -1080,7 +1083,8 @@ function init(){
   });
   if (waterAmtInput) waterAmtInput.addEventListener('input', () => {
     const err = document.getElementById('water_amount-error');
-    if (parseFloat(waterAmtInput.value) > 0) err.textContent = '';
+    const val = waterAmtInput.value.trim();
+    if (val === '' || parseFloat(val) > 0) err.textContent = '';
     else err.textContent = 'Enter a positive number.';
   });
   const potDiamUnit = document.getElementById('pot_diameter_unit');
@@ -1091,8 +1095,10 @@ function init(){
     e.preventDefault(); const form=e.target;
     if (!validateForm(form)) return;
     const data=new FormData(form);
-    data.set('water_amount',
-      form.water_amount ? parseWaterAmount(form.water_amount.value) : '');
+    if (form.water_amount) {
+      const val = form.water_amount.value.trim();
+      data.set('water_amount', val === '' ? '' : parseWaterAmount(val));
+    }
     const btn=form.querySelector('button[type="submit"]');
     btn.disabled=true;
     btn.innerHTML=(editingPlantId?ICONS.check:ICONS.plus)+


### PR DESCRIPTION
## Summary
- restructure form fields into logical sections
- allow optional water amount
- update client validation and API checks accordingly

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685e0ea06f1c8324af982510d5df7a43