### PR TITLE
Set pot diameter default unit to inches

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
                     <input type="number" id="pot_diameter" step="0.1" class="w-full border rounded-md p-2" />
                     <select id="pot_diameter_unit" class="border rounded-md p-2">
                         <option value="cm">cm</option>
-                        <option value="in">in</option>
+                        <option value="in" selected>in</option>
                     </select>
                 </div>
                 <div class="error" id="pot_diameter-error"></div>


### PR DESCRIPTION
## Summary
- change default pot diameter unit selection to inches

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685e161603008324922b2efaf5078284