### PR TITLE
Set houseplant default for calculator

### DIFF
--- a/calculator.php
+++ b/calculator.php
@@ -101,7 +101,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <label for="plant_type">Plant type:</label>
         <select name="plant_type" id="plant_type">
             <?php foreach ($config['kc_map'] as $type => $val): ?>
-                <option value="<?php echo htmlspecialchars($type); ?>" <?php if ($plant_type === $type) echo 'selected'; ?>><?php echo htmlspecialchars(ucfirst($type)); ?></option>
+                <option value="<?php echo htmlspecialchars($type); ?>" <?php if ($plant_type === $type || ($plant_type === null && $type === 'houseplant')) echo 'selected'; ?>><?php echo htmlspecialchars(ucfirst($type)); ?></option>
             <?php endforeach; ?>
         </select>
 


### PR DESCRIPTION
## Summary
- ensure `houseplant` is the default option in the plant water calculator

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685e82b477288324b1c4867a904bb119