### PR TITLE
Fix screenshot link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Plant Tracker is a lightweight PHP and JavaScript app that keeps all of your pla
 - [License](#license)
 
 ## Demo
-https://jonosmond.com/docs/screenshot.png 
+[![Screenshot of Plant Tracker](https://github.com/osmond/plant-tracker/blob/main/screenshot.png?raw=true)](index.html)
 ▶️ **[Live Demo](index.html)**
 
 ## Quickstart


### PR DESCRIPTION
## Summary
- link to GitHub-hosted screenshot instead of local file
- remove unused screenshot asset

## Testing
- `phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_685e8fb4abac8324ad5cdee06df3f5fe