### PR TITLE
Fix pot diameter editing requirement

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
         <fieldset class="form-section flex flex-col gap-4">
             <legend class="font-semibold">Pot Details</legend>
             <div>
-                <label for="pot_diameter" class="block mb-1">Pot Diameter <span id="pot_diameter_help" class="help-icon" title="Measured across the top of the pot">?</span></label>
+                <label for="pot_diameter" class="block mb-1">Pot Diameter (optional) <span id="pot_diameter_help" class="help-icon" title="Measured across the top of the pot">?</span></label>
                 <div class="flex gap-2 items-center">
                     <input type="number" id="pot_diameter" step="0.1" class="w-full border rounded-md p-2" />
                     <select id="pot_diameter_unit" class="border rounded-md p-2">

--- a/script.js
+++ b/script.js
@@ -220,13 +220,19 @@ function validateForm(form) {
   }
 
   const potDiam = form.querySelector('#pot_diameter');
-  if (potDiam) {
+  if (potDiam && potDiam.value.trim() !== '') {
     const val = parseFloat(potDiam.value);
     if (isNaN(val) || val <= 0) {
       const err = document.getElementById('pot_diameter-error');
       if (err) err.textContent = 'Enter a positive number.';
       valid = false;
+    } else {
+      const err = document.getElementById('pot_diameter-error');
+      if (err) err.textContent = '';
     }
+  } else {
+    const err = document.getElementById('pot_diameter-error');
+    if (err) err.textContent = '';
   }
 
   const waterAmtField = form.water_amount;
@@ -1121,7 +1127,12 @@ function init(){
   });
   if (potDiamInput) potDiamInput.addEventListener('blur', () => {
     const err = document.getElementById('pot_diameter-error');
-    const val = parseFloat(potDiamInput.value);
+    const valStr = potDiamInput.value.trim();
+    if (valStr === '') {
+      if (err) err.textContent = '';
+      return;
+    }
+    const val = parseFloat(valStr);
     if (!isNaN(val) && val > 0) err.textContent = '';
     else err.textContent = 'Enter a positive number.';
   });


### PR DESCRIPTION
## Summary
- mark pot diameter as optional in the form
- allow empty pot diameter values in validation and on blur

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685eb624151c8324835cf0d8bd58ec53