### PR TITLE
Improve emphasis of delete/undo messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
     </div>
 
     <!-- Undo delete snackbar -->
-    <div id="undo-banner" class="mb-4">
+    <div id="undo-banner" class="mb-4" role="alert">
         Plant deleted. <button id="undo-btn">Undo</button>
     </div>
 

--- a/style.css
+++ b/style.css
@@ -327,11 +327,16 @@ button:focus {
   bottom: calc(var(--spacing) * 1.25);
   left: 50%;
   transform: translateX(-50%);
-  background: var(--color-text);
+  background: var(--color-trash);
   color: var(--color-bg);
   padding: calc(var(--spacing) * 1.25) calc(var(--spacing) * 2);
   border-radius: var(--radius);
   z-index: 1000;
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: calc(var(--spacing) * 1);
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
@@ -343,6 +348,24 @@ button:focus {
   visibility: visible;
   pointer-events: auto;
   transition-delay: 0s;
+}
+
+#undo-btn {
+  margin-left: calc(var(--spacing) * 1);
+  font-weight: 600;
+  font-size: var(--font-size-lg);
+  padding: calc(var(--spacing) * 0.5) calc(var(--spacing) * 1.5);
+  background: var(--color-bg);
+  color: var(--color-trash);
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+#undo-btn:hover,
+#undo-btn:focus {
+  background: var(--color-trash-hover);
+  color: var(--color-bg);
 }
 
 .summary-banner {
@@ -371,6 +394,8 @@ button:focus {
   padding: calc(var(--spacing) * 1.25) calc(var(--spacing) * 2.5);
   border-radius: var(--radius);
   z-index: 1000;
+  font-size: var(--font-size-lg);
+  font-weight: 600;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s ease;


### PR DESCRIPTION
## Summary
- highlight the undo banner with larger text and accent colors
- style the Undo button and enlarge toast notifications
- add `role="alert"` for accessibility

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685eb655b474832485d8d4677087be2b