### PR TITLE
Add arrow icons for calendar nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,8 +179,8 @@
 
     <h2 id="calendar-heading" class="text-xl font-semibold p-4 flex items-center">Upcoming Tasks
         <span class="ml-auto flex gap-2">
-            <button id="prev-week" class="bg-primary text-white rounded-md px-4 py-2">Prev</button>
-            <button id="next-week" class="bg-primary text-white rounded-md px-4 py-2">Next</button>
+            <button id="prev-week" class="bg-primary text-white rounded-md px-4 py-2"></button>
+            <button id="next-week" class="bg-primary text-white rounded-md px-4 py-2"></button>
         </span>
     </h2>
     <div id="calendar" class="p-4"></div>

--- a/script.js
+++ b/script.js
@@ -126,6 +126,8 @@ const ICONS = {
   ,search: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>'
   ,calendar: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>'
   ,download: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>'
+  ,left: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>'
+  ,right: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>'
 };
 
 function showToast(msg, isError = false) {
@@ -1057,6 +1059,12 @@ function init(){
   }
   if (submitBtn) {
     submitBtn.innerHTML = ICONS.plus + '<span class="visually-hidden">Add Plant</span>';
+  }
+  if (prevBtn) {
+    prevBtn.innerHTML = ICONS.left + '<span class="visually-hidden">Previous Week</span>';
+  }
+  if (nextBtn) {
+    nextBtn.innerHTML = ICONS.right + '<span class="visually-hidden">Next Week</span>';
   }
   if (showBtn && form) {
     showBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- use empty calendar nav buttons in markup
- add arrow SVGs to icon set
- show arrow icons in JS for prev/next week

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685ef29ef37c832485546a3df506e377