### PR TITLE
Move weather icon to summary

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@
 </head>
 <body class="bg-bg text-text min-h-screen">
     <h1 class="app-title text font-bold px-4 py-0">
-        <img id="title-weather-icon" class="title-icon" alt="" style="display:none;">
         My Plant Tracker
         <button id="show-add-form" class="bg-primary text-white rounded-md px-4 py-2 ml-auto"></button>
         <button id="export-json" class="bg-primary text-white rounded-md px-4 py-2 ml-2"></button>

--- a/script.js
+++ b/script.js
@@ -506,12 +506,6 @@ function fetchWeather() {
     currentWeather = `${temp}°F ${desc}`;
     currentWeatherIcon = `https://openweathermap.org/img/wn/${icon}@2x.png`;
     currentWeatherDesc = desc;
-    const titleIcon = document.getElementById('title-weather-icon');
-    if (titleIcon) {
-      titleIcon.src = currentWeatherIcon;
-      titleIcon.alt = currentWeatherDesc;
-      titleIcon.style.display = '';
-    }
     loadPlants();
   };
 
@@ -703,17 +697,24 @@ async function loadPlants() {
 
   const row2 = document.createElement('div');
   row2.classList.add('summary-row');
-  const row2Items = [];
-  row2Items.push(`${ICONS.calendar} ${todayStr}`);
+
+  const dateSpan = document.createElement('span');
+  dateSpan.classList.add('summary-item');
+  dateSpan.innerHTML = `${ICONS.calendar} ${todayStr}`;
+  row2.appendChild(dateSpan);
+
   if (currentWeather) {
-    row2Items.push(`${currentWeather}`);
+    const weatherSpan = document.createElement('span');
+    weatherSpan.classList.add('summary-item');
+    const icon = document.createElement('img');
+    icon.id = 'weather-icon';
+    icon.classList.add('weather-icon');
+    icon.src = currentWeatherIcon;
+    icon.alt = currentWeatherDesc;
+    weatherSpan.appendChild(icon);
+    weatherSpan.insertAdjacentText('beforeend', ` ${currentWeather}`);
+    row2.appendChild(weatherSpan);
   }
-  row2Items.forEach(text => {
-    const span = document.createElement('span');
-    span.classList.add('summary-item');
-    span.innerHTML = text;
-    row2.appendChild(span);
-  });
 
   summaryEl.appendChild(row1);
   summaryEl.appendChild(row2);


### PR DESCRIPTION
## Summary
- remove weather icon from the page header
- render current weather icon within the summary section
- update weather fetch helper to only store data and trigger refresh

## Testing
- `php -d detect_unicode=0 ./vendor/bin/phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef73ff3b88324a1d3cea3ccc36593