### PR TITLE
Add responsive images and caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ node_modules/
 *.tmp
 db.php
 uploads/
+!uploads/.htaccess
 plant-tracker-starter.code-workspace
 Archive.zip

--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -86,6 +86,7 @@ if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
 
         if (move_uploaded_file($_FILES['photo']['tmp_name'], $dest)) {
             $converted = convert_to_webp($dest);
+            generate_responsive_variants($converted);
             $photo_url = 'uploads/' . basename($converted);
         }
     }

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -112,6 +112,7 @@ if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
                 }
             }
             $converted = convert_to_webp($dest);
+            generate_responsive_variants($converted);
             $photo_url = 'uploads/' . basename($converted);
         }
     }

--- a/image_utils.php
+++ b/image_utils.php
@@ -26,4 +26,26 @@ function convert_to_webp(string $path): string {
         return $path;
     }
 }
+
+function generate_responsive_variants(string $path): void {
+    if (!extension_loaded('imagick') || !file_exists($path)) {
+        return;
+    }
+    $sizes = [400, 800];
+    foreach ($sizes as $width) {
+        try {
+            $img = new Imagick($path);
+            if (method_exists($img, 'autoOrient')) {
+                $img->autoOrient();
+            }
+            $img->resizeImage($width, 0, Imagick::FILTER_LANCZOS, 1);
+            $variantPath = preg_replace('/\.webp$/i', "-{$width}.webp", $path);
+            $img->writeImage($variantPath);
+            $img->clear();
+            $img->destroy();
+        } catch (Exception $e) {
+            // ignore errors
+        }
+    }
+}
 ?>

--- a/script.js
+++ b/script.js
@@ -768,6 +768,13 @@ async function loadPlants() {
       img.alt = 'No photo available for ' + plant.name;
     }
     img.loading = 'lazy';
+    img.width = 300;
+    img.height = 300;
+    if (plant.photo_url && plant.photo_url.endsWith('.webp')) {
+      const base = plant.photo_url.slice(0, -5);
+      img.srcset = `${base}-400.webp 400w, ${plant.photo_url} 800w`;
+      img.sizes = '(max-width: 640px) 100vw, 400px';
+    }
     img.classList.add('plant-photo');
     card.appendChild(img);
     const titleEl = document.createElement('h3');

--- a/uploads/.htaccess
+++ b/uploads/.htaccess
@@ -1,0 +1,10 @@
+<IfModule mod_expires.c>
+  ExpiresActive On
+  ExpiresByType image/webp "access plus 1 year"
+  ExpiresByType image/jpeg "access plus 1 year"
+  ExpiresByType image/png "access plus 1 year"
+  ExpiresByType image/gif "access plus 1 year"
+</IfModule>
+<IfModule mod_headers.c>
+  Header set Cache-Control "public, max-age=31536000"
+</IfModule>


### PR DESCRIPTION
## Summary
- generate responsive image variants when uploading
- load responsive images with `srcset` in plant cards
- add caching headers for uploaded images
- store uploads `.htaccess`

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685ef63a66608324b803c28245e7824d