### PR TITLE
Allow periods in species name

### DIFF
--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -49,7 +49,7 @@ $photo_url = trim($_POST['photo_url'] ?? '');
 
 // further validation
 $errors = [];
-if ($species !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,100}$/', $species)) {
+if ($species !== '' && !preg_match('/^[A-Za-z0-9\s.-]{1,100}$/', $species)) {
     $errors[] = 'Invalid species';
 }
 if ($room !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,50}$/', $room)) {

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -51,7 +51,7 @@ if ($photo_url === '' && (!isset($_FILES['photo']) || $_FILES['photo']['error'] 
 }
 
 // further validation
-if ($species !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,100}$/', $species)) {
+if ($species !== '' && !preg_match('/^[A-Za-z0-9\s.-]{1,100}$/', $species)) {
     $errors[] = 'Invalid species';
 }
 if ($room !== '' && !preg_match('/^[A-Za-z0-9\s-]{1,50}$/', $room)) {

--- a/script.js
+++ b/script.js
@@ -309,7 +309,7 @@ function validateForm(form) {
   // additional constraints
   const species = form.querySelector('[name="species"]');
   if (species && species.value.trim() &&
-      !/^[A-Za-z0-9\s-]{1,100}$/.test(species.value.trim())) {
+      !/^[A-Za-z0-9\s.-]{1,100}$/.test(species.value.trim())) {
     document.getElementById('species-error').textContent =
       'Invalid characters or too long.';
     valid = false;

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -115,5 +115,37 @@ class ApiTest extends TestCase
         $data = json_decode($output, true);
         $this->assertArrayHasKey('error', $data);
     }
+
+    public function testAddPlantWithPeriodInSpecies()
+    {
+        $_POST = [
+            'name' => 'Period Plant',
+            'watering_frequency' => 5,
+            'species' => 'Oxytropis nuda Basil.'
+        ];
+        ob_start();
+        include __DIR__ . '/../api/add_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('success', $data['status']);
+    }
+
+    public function testUpdatePlantWithPeriodInSpecies()
+    {
+        $_POST = [
+            'id' => 1,
+            'name' => 'Updated',
+            'watering_frequency' => 7,
+            'species' => 'Oxytropis nuda Basil.',
+            'water_amount' => 150,
+            'last_watered' => '',
+            'last_fertilized' => ''
+        ];
+        ob_start();
+        include __DIR__ . '/../api/update_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('success', $data['status']);
+    }
 }
 ?>


### PR DESCRIPTION
## Summary
- accept periods in species input on both frontend and backend
- extend API tests for species containing a period

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685f4d315a408324994f626c4639ff1d