### PR TITLE
Fix summary due calculations for local date parsing

### DIFF
--- a/script.js
+++ b/script.js
@@ -809,11 +809,11 @@ async function loadPlants() {
   const totalPlants = filtered.length;
   filtered.forEach(p => {
     if (p.last_watered) {
-      const nxt = addDays(new Date(p.last_watered), p.watering_frequency);
+      const nxt = addDays(parseLocalDate(p.last_watered), p.watering_frequency);
       if (nxt <= today) wateringDue++;
     }
     if (p.last_fertilized && p.fertilizing_frequency) {
-      const nxt = addDays(new Date(p.last_fertilized), p.fertilizing_frequency);
+      const nxt = addDays(parseLocalDate(p.last_fertilized), p.fertilizing_frequency);
       if (nxt <= today) fertilizingDue++;
     }
   });


### PR DESCRIPTION
## Summary
- use `parseLocalDate` when computing the number of plants needing watering/fertilizing

## Testing
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_685f5b60906c83248ff5a72a32057289