### PR TITLE
Alphabetize room filter options

### DIFF
--- a/script.js
+++ b/script.js
@@ -1110,7 +1110,9 @@ async function loadPlants() {
 
   const roomSet = new Set();
   plants.forEach(p => { if (p.room) roomSet.add(p.room); });
-  const rooms = Array.from(roomSet);
+  const rooms = Array.from(roomSet).sort((a, b) =>
+    a.localeCompare(b, undefined, { sensitivity: 'base' })
+  );
 
   const filter = document.getElementById('room-filter');
   if (filter) {


### PR DESCRIPTION
## Summary
- keep room lists sorted alphabetically so filter and datalist options are easier to browse

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685f5d02a7248324b01fbd01ecaf1dd0