### PR TITLE
Add GBIF specimen photo thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Database credentials are taken from the environment variables `DB_HOST`, `DB_USE
 2. Upload a photo and fill out the care schedule.
 3. Type a plant name to automatically fetch matching scientific names from the GBIF Species API.
 4. Selecting a suggestion shows its classification, common names and synonyms beneath the field.
-5. View upcoming tasks in the calendar and drag them to reschedule.
+5. If available, specimen photos from GBIF appear as thumbnails for quick reference.
+6. View upcoming tasks in the calendar and drag them to reschedule.
 
 Uploaded images are stored in `uploads/` and automatically converted to WebP when possible.
 

--- a/script.js
+++ b/script.js
@@ -185,16 +185,34 @@ async function fetchSynonyms(key) {
   }
 }
 
+async function fetchSpecimenPhotos(key) {
+  if (!key) return [];
+  try {
+    const imgRes = await fetch(
+      `https://api.gbif.org/v1/occurrence/search?taxonKey=${key}&mediaType=StillImage&limit=5`
+    );
+    if (!imgRes.ok) return [];
+    const data = await imgRes.json();
+    return (data.results || [])
+      .flatMap(o => o.media || [])
+      .map(m => m.identifier)
+      .filter(Boolean);
+  } catch (e) {
+    return [];
+  }
+}
+
 async function showTaxonomyInfo(name) {
   const infoEl = document.getElementById('taxonomy-info');
   if (!infoEl) return;
   infoEl.textContent = '';
   const key = await getSpeciesKey(name);
   if (!key) return;
-  const [classification, common, syn] = await Promise.all([
+  const [classification, common, syn, photos] = await Promise.all([
     fetchClassification(key),
     fetchCommonNames(key),
     fetchSynonyms(key),
+    fetchSpecimenPhotos(key),
   ]);
   if (classification) {
     const div = document.createElement('div');
@@ -219,6 +237,18 @@ async function showTaxonomyInfo(name) {
     div.appendChild(strong);
     div.appendChild(document.createTextNode(' ' + syn.join(', ')));
     infoEl.appendChild(div);
+  }
+  if (photos && photos.length) {
+    const gallery = document.createElement('div');
+    gallery.classList.add('specimen-gallery');
+    photos.forEach(url => {
+      const img = document.createElement('img');
+      img.src = url;
+      img.alt = name + ' specimen';
+      img.loading = 'lazy';
+      gallery.appendChild(img);
+    });
+    infoEl.appendChild(gallery);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -141,6 +141,19 @@ form {
     margin-top: calc(var(--spacing) / 4);
 }
 
+.specimen-gallery {
+    display: flex;
+    gap: calc(var(--spacing) / 2);
+    margin-top: calc(var(--spacing) / 2);
+}
+
+.specimen-gallery img {
+    width: 60px;
+    height: 60px;
+    object-fit: cover;
+    border-radius: var(--radius);
+}
+
 .form-progress {
     font-size: 0.9em;
     margin-bottom: calc(var(--spacing));


### PR DESCRIPTION
## Summary
- show GBIF occurrence images as thumbnails in the taxonomy info card
- style new specimen gallery
- document new capability in README

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685f60202a7483248dd13cc49e990343