### PR TITLE
Limit scientific name suggestions to plants

### DIFF
--- a/script.js
+++ b/script.js
@@ -94,7 +94,7 @@ async function fetchScientificNames(query) {
   if (!query) return [];
   try {
     const res = await fetch(
-      `https://api.gbif.org/v1/species/search?q=${encodeURIComponent(query)}&limit=10`
+      `https://api.gbif.org/v1/species/search?q=${encodeURIComponent(query)}&kingdomKey=6&rank=species&limit=10`
     );
     if (!res.ok) return [];
     const json = await res.json();


### PR DESCRIPTION
## Summary
- restrict `fetchScientificNames` to the Plantae kingdom

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685f5fa6b148832497a34f18e804b004