### PR TITLE
Allow selecting GBIF thumbnail as plant photo

### DIFF
--- a/script.js
+++ b/script.js
@@ -274,6 +274,25 @@ async function showTaxonomyInfo(name) {
       img.src = url;
       img.alt = name + ' specimen';
       img.loading = 'lazy';
+
+      // allow user to select a specimen photo
+      img.addEventListener('click', () => {
+        // remove previous selection
+        gallery.querySelectorAll('img').forEach(i => i.classList.remove('selected'));
+        img.classList.add('selected');
+
+        const photoUrlInput = document.getElementById('photo_url');
+        if (photoUrlInput) photoUrlInput.value = url;
+
+        const drop = document.getElementById('photo-drop');
+        if (drop) {
+          drop.textContent = 'Using specimen photo';
+          drop.style.backgroundImage = `url(${url})`;
+          drop.style.backgroundSize = 'cover';
+          drop.style.color = 'white';
+        }
+      });
+
       gallery.appendChild(img);
     });
     infoEl.appendChild(gallery);

--- a/style.css
+++ b/style.css
@@ -152,6 +152,12 @@ form {
     height: 60px;
     object-fit: cover;
     border-radius: var(--radius);
+    cursor: pointer;
+    border: 2px solid transparent;
+}
+
+.specimen-gallery img.selected {
+    border-color: #34d399; /* Tailwind green-300 */
 }
 
 .form-progress {


### PR DESCRIPTION
## Summary
- highlight selectable specimen thumbnails
- update taxonomy info UI so clicking a thumbnail chooses it as the photo

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685fd18aecf8832486f67b502eddb3c7