### PR TITLE
Show precipitation only for outside room

### DIFF
--- a/script.js
+++ b/script.js
@@ -1018,7 +1018,8 @@ async function loadPlants() {
 
   summaryEl.appendChild(row1);
   summaryEl.appendChild(row2);
-  if (rainPastInches.length === 3 && rainForecastInches.length === 3) {
+  if (selectedRoom === 'outside' &&
+      rainPastInches.length === 3 && rainForecastInches.length === 3) {
     const row3 = document.createElement('div');
     row3.classList.add('summary-row');
     const pastSpan = document.createElement('span');


### PR DESCRIPTION
## Summary
- only append rainfall summary rows when the `room-filter` is set to `outside`

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_685fdb34e9f8832483d03d8ad13eea15