### PR TITLE
Improve layout responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     </script>
 </head>
 <body class="bg-bg text-text min-h-screen">
+  <div class="main-container">
     <h1 class="app-title text font-bold px-4 py-0">
         My Plant Tracker
         <button id="show-add-form" class="bg-primary text-white rounded-md px-4 py-2 ml-auto"></button>
@@ -153,7 +154,7 @@
         </div>
     </form>
 
-    <div class="my-4 flex flex-wrap gap-2 p-4">
+    <div class="filter-bar">
         <select id="room-filter" class="border rounded-md">
             <option value="all" selected>All Rooms</option>
         </select>
@@ -192,6 +193,8 @@
         </span>
     </h2>
     <div id="calendar" class="p-4"></div>
+
+    </div> <!-- /.main-container -->
 
     <script>
       const script = document.createElement('script');

--- a/style.css
+++ b/style.css
@@ -49,6 +49,13 @@
   --font-size-xl: 1.5rem;      /* 24px extra large text */
 }
 
+/* ---- centered max-width wrapper ---- */
+.main-container {
+  margin: 0 auto;
+  padding: 0 1rem;
+  max-width: 80rem;
+}
+
 .bg-primary {
   background-color: var(--color-primary);
   color: var(--color-surface);
@@ -64,6 +71,19 @@ body {
     padding: calc(var(--spacing) * 2.5);
     margin: auto;
     max-width: 100%;
+}
+
+/* ---- filter bar ---- */
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--spacing);
+  margin-bottom: calc(var(--spacing) * 2);
+}
+
+.filter-bar select {
+  padding: 0.5rem 0.75rem;
 }
 
 h1, h2, h3 {
@@ -533,43 +553,44 @@ button:focus {
   border-radius: var(--radius);
 }
 
-/* simple calendar styles */
+/* ---- calendar grid ---- */
 #calendar {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: calc(var(--spacing) * 2);
-  margin-top: calc(var(--spacing) * 2);
+  gap: var(--spacing);
+  grid-template-columns: repeat(2, 1fr);
+  overflow-x: auto;
 }
+@media (min-width: 640px)  { #calendar { grid-template-columns: repeat(3, 1fr); } }
+@media (min-width: 768px)  { #calendar { grid-template-columns: repeat(4, 1fr); } }
+@media (min-width: 1024px) { #calendar { grid-template-columns: repeat(7, 1fr); } }
 
 #calendar.hidden {
   display: none;
 }
 
 #calendar .cal-day {
+  display: flex;
+  flex-direction: column;
+  padding: var(--spacing);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
-  padding: var(--spacing);
   min-height: 140px;
-  display: flex;
-  flex-direction: column;
 }
 
 
 #calendar .cal-day-header {
   font-weight: 600;
   margin-bottom: calc(var(--spacing));
-  padding-bottom: calc(var(--spacing) / 2);
   border-bottom: 1px solid var(--color-border);
+  padding-bottom: calc(var(--spacing) / 2);
 }
 
 #calendar .cal-event {
-  background: var(--color-bg);
-  margin-bottom: calc(var(--spacing) / 2);
+  margin-top: calc(var(--spacing) / 2);
   padding: calc(var(--spacing) / 2);
   border-radius: var(--radius);
-  cursor: move;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  font-size: var(--font-size-sm);
 }
 
 #calendar .cal-event.water-due {
@@ -583,79 +604,48 @@ button:focus {
 }
 
 
-/* card layout */
+/* ---- grid view ---- */
 #plant-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   gap: calc(var(--spacing) * 2);
-}
-
-@media (min-width: 1000px) {
-  #plant-grid {
-    grid-template-columns: repeat(auto-fill, minmax(366px, 1fr));
-  }
-}
-
-@media (max-width: 640px) {
-  #plant-grid {
-    /* Force a single column layout on small screens */
-    grid-template-columns: 1fr;
-    margin-left: calc(var(--spacing) * 2);
-    margin-right: calc(var(--spacing) * 2);
-  }
-
-  body {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}
-
-/* list view layout overrides */
-#plant-grid.list-view {
-  display: flex;
-  flex-direction: column;
-  gap: calc(var(--spacing) * 1.5);
-  max-width: 48rem;
-  margin-left: auto;
-  margin-right: auto;
-  padding: calc(var(--spacing) * 2);
-}
-
-#plant-grid.list-view .plant-card {
-  flex-direction: column;
-  gap: calc(var(--spacing) * 2);
-  padding: calc(var(--spacing) * 2);
-  border-bottom: 1px solid #e5e7eb;
-  transition: background-color 0.2s, box-shadow 0.2s;
-}
-
-#plant-grid.list-view .plant-card:hover {
-  background-color: #f9fafb;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-}
-
-#plant-grid.list-view .plant-card:last-child {
-  border-bottom: none;
-}
-
-#plant-grid.list-view .plant-photo {
-  width: 64px;
-  height: 64px;
-  margin-right: 0;
-  margin-bottom: 0;
-  flex-shrink: 0;
+  grid-template-columns: repeat(1, 1fr);
 }
 
 @media (min-width: 640px) {
-  #plant-grid.list-view .plant-card {
-    flex-direction: row;
-    align-items: center;
-  }
+  #plant-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 768px) {
+  #plant-grid { grid-template-columns: repeat(3, 1fr); }
+}
+@media (min-width: 1024px) {
+  #plant-grid { grid-template-columns: repeat(4, 1fr); }
+}
 
-  #plant-grid.list-view .plant-photo {
-    width: 80px;
-    height: 80px;
-  }
+/* ---- list view overrides ---- */
+#plant-grid.list-view {
+  display: grid;
+  gap: calc(var(--spacing) * 1.5);
+  grid-template-columns: 1fr;
+  max-width: 48rem;
+  margin: 0 auto;
+  padding: 0 var(--spacing);
+}
+
+#plant-grid.list-view .plant-card {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing);
+  padding: calc(var(--spacing) * 1.5);
+  border-bottom: 1px solid #e5e7eb;
+  box-shadow: none;
+}
+
+#plant-grid.list-view .plant-photo {
+  flex-shrink: 0;
+  width: 80px;
+  height: 80px;
+  border-radius: var(--radius);
+  object-fit: cover;
 }
 
 #plant-grid.list-view .plant-info {
@@ -668,6 +658,13 @@ button:focus {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+#plant-grid.list-view .actions {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing);
 }
 
 /* text only view */
@@ -704,6 +701,7 @@ button:focus {
   padding: calc(var(--spacing) * 2);
   display: flex;
   flex-direction: column;
+  justify-content: space-between;
   overflow: hidden; /* clip photo when it extends to edges */
   position: relative; /* allow urgency tag overlay */
   box-shadow: 0 1px 2px rgba(0,0,0,0.05);
@@ -730,27 +728,7 @@ button:focus {
 }
 
 #plant-grid.list-view .actions {
-  margin-top: calc(var(--spacing) * 2);
-  justify-content: flex-end;
-}
-
-#plant-grid.list-view .actions-left,
-#plant-grid.list-view .actions-right {
-  display: flex;
-  gap: var(--spacing);
-}
-
-@media (min-width: 640px) {
-  #plant-grid.list-view .actions {
-    margin-top: 0;
-    margin-left: calc(var(--spacing) * 1.5);
-    flex-direction: column;
-  }
-
-  #plant-grid.list-view .actions-left,
-  #plant-grid.list-view .actions-right {
-    flex-direction: column;
-  }
+  margin-top: 0;
 }
 
 .plant-card .actions .action-btn {


### PR DESCRIPTION
## Summary
- center content within a new `.main-container` wrapper
- wrap select filters inside a `.filter-bar` flex container
- rework grid, list, text and calendar layouts for better responsiveness

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686038c2100883249a7d7a8e66c90fc3