### PR TITLE
Fix grid view action buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -1276,29 +1276,9 @@ async function loadPlants() {
     changeBtn.title = 'Add Image';
     changeBtn.onclick = () => fileInput.click();
 
-    const menu = document.createElement('div');
-    menu.classList.add('more-menu');
-    menu.appendChild(editBtn);
-    menu.appendChild(delBtn);
-    menu.appendChild(changeBtn);
-
-    const wrapper = document.createElement('div');
-    wrapper.classList.add('more-wrapper');
-    const moreBtn = document.createElement('button');
-    moreBtn.classList.add('action-btn', 'more-btn');
-    moreBtn.innerHTML = ICONS.more + '<span class="visually-hidden">More</span>';
-    moreBtn.type = 'button';
-    moreBtn.onclick = (e) => {
-      e.stopPropagation();
-      menu.classList.toggle('show');
-    };
-    wrapper.appendChild(moreBtn);
-    wrapper.appendChild(menu);
-    document.addEventListener('click', (e) => {
-      if (!wrapper.contains(e.target)) menu.classList.remove('show');
-    });
-
-    rightGroup.appendChild(wrapper);
+    rightGroup.appendChild(editBtn);
+    rightGroup.appendChild(delBtn);
+    rightGroup.appendChild(changeBtn);
     actionsDiv.appendChild(leftGroup);
     actionsDiv.appendChild(rightGroup);
     actionsDiv.appendChild(fileInput);

--- a/style.css
+++ b/style.css
@@ -279,27 +279,6 @@ button:focus {
     transform: translateY(0);
 }
 
-.more-wrapper {
-  position: relative;
-}
-
-.more-menu {
-  display: none;
-  position: absolute;
-  right: 0;
-  top: 100%;
-  background: var(--color-surface);
-  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
-  border-radius: var(--radius);
-  padding: calc(var(--spacing) / 2);
-  z-index: 10;
-  flex-direction: column;
-  gap: var(--spacing);
-}
-
-.more-menu.show {
-  display: flex;
-}
 
 .view-toggle-group {
     display: inline-flex;


### PR DESCRIPTION
## Summary
- show edit, delete and photo buttons directly on grid cards again
- remove obsolete dropdown menu styling

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68604eebd3ec832481f685a079a04d9e