### PR TITLE
Implement view-based action menu

### DIFF
--- a/script.js
+++ b/script.js
@@ -915,10 +915,6 @@ async function loadPlants() {
   const res = await fetch('api/get_plants.php');
   const plants = await res.json();
   const list = document.getElementById('plant-grid');
-  if (list) {
-    list.classList.toggle('list-view', viewMode === 'list');
-    list.classList.toggle('text-view', viewMode === 'text');
-  }
   const selectedRoom = document.getElementById('room-filter').value;
   const dueFilter = document.getElementById('due-filter')
     ? document.getElementById('due-filter').value
@@ -1279,6 +1275,36 @@ async function loadPlants() {
     rightGroup.appendChild(editBtn);
     rightGroup.appendChild(delBtn);
     rightGroup.appendChild(changeBtn);
+
+    const menu = document.createElement('div');
+    menu.classList.add('more-menu');
+    const editClone = editBtn.cloneNode(true);
+    editClone.onclick = editBtn.onclick;
+    const delClone = delBtn.cloneNode(true);
+    delClone.onclick = delBtn.onclick;
+    const changeClone = changeBtn.cloneNode(true);
+    changeClone.onclick = changeBtn.onclick;
+    menu.appendChild(editClone);
+    menu.appendChild(delClone);
+    menu.appendChild(changeClone);
+
+    const wrapper = document.createElement('div');
+    wrapper.classList.add('more-wrapper');
+    const moreBtn = document.createElement('button');
+    moreBtn.classList.add('action-btn', 'more-btn');
+    moreBtn.innerHTML = ICONS.more + '<span class="visually-hidden">More</span>';
+    moreBtn.type = 'button';
+    moreBtn.onclick = (e) => {
+      e.stopPropagation();
+      menu.classList.toggle('show');
+    };
+    wrapper.appendChild(moreBtn);
+    wrapper.appendChild(menu);
+    document.addEventListener('click', (e) => {
+      if (!wrapper.contains(e.target)) menu.classList.remove('show');
+    });
+
+    rightGroup.appendChild(wrapper);
     actionsDiv.appendChild(leftGroup);
     actionsDiv.appendChild(rightGroup);
     actionsDiv.appendChild(fileInput);

--- a/style.css
+++ b/style.css
@@ -279,6 +279,29 @@ button:focus {
     transform: translateY(0);
 }
 
+.more-wrapper {
+  position: relative;
+  display: none;
+}
+
+.more-menu {
+  display: none;
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: var(--color-surface);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+  border-radius: var(--radius);
+  padding: calc(var(--spacing) / 2);
+  z-index: 10;
+  flex-direction: column;
+  gap: var(--spacing);
+}
+
+.more-menu.show {
+  display: flex;
+}
+
 
 .view-toggle-group {
     display: inline-flex;
@@ -673,8 +696,7 @@ button:focus {
 
 /* text only view */
 #plant-grid.text-view .plant-photo,
-#plant-grid.text-view .tag-list,
-#plant-grid.text-view .actions {
+#plant-grid.text-view .tag-list {
   display: none !important;
 }
 
@@ -741,6 +763,20 @@ button:focus {
 #plant-grid.list-view .actions-right {
   display: flex;
   gap: var(--spacing);
+}
+
+#plant-grid.grid-view .actions-left,
+#plant-grid.grid-view .actions-right {
+  display: none;
+}
+
+#plant-grid.grid-view .more-wrapper {
+  display: flex;
+}
+
+#plant-grid.list-view .more-wrapper,
+#plant-grid.text-view .more-wrapper {
+  display: none;
 }
 
 @media (min-width: 640px) {


### PR DESCRIPTION
## Summary
- add kebab dropdown markup and clone action buttons into it
- hide inline icons in grid view but show kebab menu
- hide kebab menu in list and text views
- stop toggling view classes inside `loadPlants`
- keep actions visible in text view

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6860525dcb2083248ddcf6fd92e22049