### PR TITLE
Fix uniform plant photo sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -838,18 +838,13 @@ button:focus {
 .plant-card .plant-photo {
   width: 100%;
   height: 150px;
+  aspect-ratio: 1/1;
   object-fit: cover;
   display: block;
   margin-bottom: calc(var(--spacing) * 1.5);
   border-radius: 12px;
 }
 
-@media (min-width: 1000px) {
-  .plant-card .plant-photo {
-    height: auto;
-    max-height: 400px;
-  }
-}
 
 .plant-card.due-overdue,
 .plant-card.due-today,


### PR DESCRIPTION
## Summary
- keep thumbnails same size on all screens by removing special large-screen rules
- use CSS `aspect-ratio` to lock square thumbnails

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68605e7032788324baed328f8151de1c