### PR TITLE
Ensure plant species visible on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1095,7 +1095,6 @@ button:focus {
 }
 
 @media (max-width: 500px) {
-  .plant-card .plant-species,
   .plant-card .amt-tag {
     display: none;
   }


### PR DESCRIPTION
## Summary
- remove `.plant-species` from the 500px media query so species are visible on all viewports

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686060af48fc832498e5c1fe2707a18e