### PR TITLE
Improve Care Schedule layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -1194,26 +1194,34 @@ async function loadPlants() {
     heading.textContent = 'Care Schedule';
     summary.appendChild(heading);
 
-    const waterSummary = document.createElement('span');
+    const waterSummary = document.createElement('div');
     waterSummary.classList.add('summary-item');
+    const waterIconWrap = document.createElement('span');
+    waterIconWrap.innerHTML = ICONS.water;
     const waterNext = formatDateShort(getNextWaterDate(plant));
-    waterSummary.innerHTML =
-      ICONS.water +
-
-      ` Water every ${plant.watering_frequency} days. Last ${formatDateShort(plant.last_watered)}, next ${waterNext}.`;
+    const waterText = document.createElement('span');
+    waterText.textContent =
+      `Water every ${plant.watering_frequency} days. ` +
+      `Last ${formatDateShort(plant.last_watered)}, next ${waterNext}.`;
+    waterSummary.appendChild(waterIconWrap);
+    waterSummary.appendChild(waterText);
 
     summary.appendChild(waterSummary);
 
-    const fertSummary = document.createElement('span');
+    const fertSummary = document.createElement('div');
     fertSummary.classList.add('summary-item');
+    const fertIconWrap = document.createElement('span');
+    fertIconWrap.innerHTML = ICONS.fert;
     const fertFreq = plant.fertilizing_frequency
       ? `${plant.fertilizing_frequency} days`
       : 'N/A';
     const fertNext = getNextFertDate(plant);
-    fertSummary.innerHTML =
-      ICONS.fert +
-
-      ` Fertilize every ${fertFreq}. Last ${formatDateShort(plant.last_fertilized)}, next ${fertNext ? formatDateShort(fertNext) : 'N/A'}.`;
+    const fertText = document.createElement('span');
+    fertText.textContent =
+      `Fertilize every ${fertFreq}. ` +
+      `Last ${formatDateShort(plant.last_fertilized)}, next ${fertNext ? formatDateShort(fertNext) : 'N/A'}.`;
+    fertSummary.appendChild(fertIconWrap);
+    fertSummary.appendChild(fertText);
 
     summary.appendChild(fertSummary);
 

--- a/style.css
+++ b/style.css
@@ -922,9 +922,10 @@ button:focus {
 
 
 .plant-summary .summary-item {
-  display: flex;
-  align-items: center;
-  gap: 4px;
+  display: grid;
+  grid-template-columns: 1.25em 1fr;
+  column-gap: 4px;
+  align-items: start;
 }
 
 .plant-summary .water-amount {


### PR DESCRIPTION
## Summary
- adjust Care Schedule rendering to use structured icon + text
- align care schedule rows via CSS grid

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6860644b8dbc8324bfeebb5b1bd7280f