### PR TITLE
Make snooze dropdown same size as action buttons

### DIFF
--- a/style.css
+++ b/style.css
@@ -791,7 +791,7 @@ button:focus {
 
 /* small dropdown for snoozing tasks */
 .snooze-select {
-  width: 100%;
+  width: 2.5rem;
   height: 2.5rem;
   padding: calc(var(--spacing) / 2);
   border: 1px solid var(--color-border);


### PR DESCRIPTION
## Summary
- keep snooze dropdowns the same size as the other action buttons

## Testing
- `phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6860650de5708324905e0b2e98d0d4bd