### PR TITLE
Add citrus plant type

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -9,6 +9,8 @@ return [
         'houseplant' => 0.8,
         'vegetable'  => 1.0,
         'cacti'      => 0.28,
+        'flower'     => 0.9,
+        'citrus'     => 0.7,
     ],
     'bed_map' => [
         'vegetable' => [

--- a/config.php
+++ b/config.php
@@ -9,6 +9,8 @@ return [
         'houseplant' => 0.8,
         'vegetable'  => 1.0,
         'cacti'      => 0.28,
+        'flower'     => 0.9,
+        'citrus'     => 0.7,
     ],
     'bed_map' => [
         'vegetable' => [

--- a/index.html
+++ b/index.html
@@ -70,6 +70,8 @@
                     <option value="houseplant" selected>Houseplant</option>
                     <option value="vegetable">Vegetable</option>
                     <option value="cacti">Cacti</option>
+                    <option value="flower">Flower</option>
+                    <option value="citrus">Citrus</option>
                 </select>
             </div>
             <div>

--- a/script.js
+++ b/script.js
@@ -28,6 +28,8 @@ const KC_MAP = {
   houseplant: 0.8,
   vegetable: 1.0,
   cacti: 0.28,
+  flower: 0.9,
+  citrus: 0.7,
 };
 
 let weatherTminC = null;
@@ -340,6 +342,8 @@ function updateWateringFrequency() {
   if (type === 'succulent') base = 14;
   else if (type === 'cacti') base = 21;
   else if (type === 'vegetable') base = 3;
+  else if (type === 'flower') base = 5;
+  else if (type === 'citrus') base = 6;
   let diam = parseFloat(potInput ? potInput.value : '');
   if (!isNaN(diam)) {
     const unit = unitSelect ? unitSelect.value : 'cm';


### PR DESCRIPTION
## Summary
- add citrus kc value in default configs
- support citrus option in plant selector and calculator

## Testing
- `phpunit -c phpunit.xml --testsuite default`

------
https://chatgpt.com/codex/tasks/task_e_68606da081e08324b0dd143d8b139d4a