### PR TITLE
Add plant_type field

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Edit `config.php` and provide:
 - `openweather_key` – your OpenWeather API key
 - `location` – city name used for weather lookups
 - `ra`, `kc` and mapping values for water calculations
+- `kc_map` defines coefficients for each `plant_type`
 
 The app fetches rainfall using OpenWeather's **forecast** endpoint.
 
@@ -49,7 +50,7 @@ Database credentials are taken from the environment variables `DB_HOST`, `DB_USE
 ## Usage
 
 1. Click **Add Plant** to create a new entry.
-2. Upload a photo and fill out the care schedule.
+2. Choose a plant type, upload a photo and fill out the care schedule.
 3. Type a plant name to automatically fetch matching scientific names from the GBIF Species API.
 4. Selecting a suggestion shows its classification, common names and synonyms beneath the field.
 5. If available, specimen photos from GBIF appear as thumbnails for quick reference.

--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -42,6 +42,7 @@ $species = trim($_POST['species'] ?? '');
 $room = trim($_POST['room'] ?? '');
 $watering_frequency = intval($_POST['watering_frequency'] ?? 0);
 $fertilizing_frequency = intval($_POST['fertilizing_frequency'] ?? 0);
+$plant_type = trim($_POST['plant_type'] ?? 'houseplant');
 $water_amount = isset($_POST['water_amount']) ? floatval($_POST['water_amount']) : 0;
 $last_watered = $_POST['last_watered'] ?? null;
 $last_fertilized = $_POST['last_fertilized'] ?? null;
@@ -57,6 +58,9 @@ if ($room !== '' && !preg_match('/^[\p{L}0-9\s-]{1,50}$/u', $room)) {
 }
 if ($watering_frequency < 1 || $watering_frequency > 365) {
     $errors[] = 'Watering frequency must be 1-365';
+}
+if ($plant_type !== '' && !preg_match('/^[a-zA-Z_\s-]{1,50}$/', $plant_type)) {
+    $errors[] = 'Invalid plant type';
 }
 if ($water_amount < 0) {
     $errors[] = 'Water amount must be non-negative';
@@ -101,11 +105,12 @@ $stmt = $conn->prepare(
         room,
         watering_frequency,
         fertilizing_frequency,
+        plant_type,
         last_watered,
         last_fertilized,
         photo_url,
         water_amount
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 );
 if (!$stmt) {
     @http_response_code(500);
@@ -120,12 +125,13 @@ if (!$stmt) {
     return;
 }
 $stmt->bind_param(
-    "sssiisssd",
+    "sssiissssd",
     $name,
     $species,
     $room,
     $watering_frequency,
     $fertilizing_frequency,
+    $plant_type,
     $last_watered,
     $last_fertilized,
     $photo_url,

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -17,7 +17,7 @@ if (!headers_sent()) {
 
 $plants = [];
 $result = $conn->query(
-    "SELECT id, name, species, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount
+    "SELECT id, name, species, watering_frequency, fertilizing_frequency, plant_type, room, last_watered, last_fertilized, photo_url, water_amount
     FROM plants
     ORDER BY id DESC"
 );

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -24,6 +24,7 @@ $species                 = trim($_POST['species'] ?? '');
 $room                    = trim($_POST['room'] ?? '');
 $watering_frequency      = intval($_POST['watering_frequency'] ?? 0);
 $fertilizing_frequency   = intval($_POST['fertilizing_frequency'] ?? 0);
+$plant_type             = trim($_POST['plant_type'] ?? 'houseplant');
 $water_amount            = isset($_POST['water_amount']) ? floatval($_POST['water_amount']) : 0;
 $last_watered            = $_POST['last_watered'] ?? null;
 $last_fertilized         = $_POST['last_fertilized'] ?? null;
@@ -59,6 +60,9 @@ if ($room !== '' && !preg_match('/^[\p{L}0-9\s-]{1,50}$/u', $room)) {
 }
 if ($watering_frequency < 1 || $watering_frequency > 365) {
     $errors[] = 'Watering frequency must be 1-365';
+}
+if ($plant_type !== '' && !preg_match('/^[a-zA-Z_\s-]{1,50}$/', $plant_type)) {
+    $errors[] = 'Invalid plant type';
 }
 if ($water_amount < 0) {
     $errors[] = 'Water amount must be non-negative';
@@ -137,6 +141,7 @@ $stmt = $conn->prepare("
         room               = ?,
         watering_frequency = ?,
         fertilizing_frequency = ?,
+        plant_type         = ?,
         last_watered       = ?,
         last_fertilized    = ?,
         photo_url          = ?,
@@ -144,12 +149,13 @@ $stmt = $conn->prepare("
     WHERE id = ?
 ");
 $stmt->bind_param(
-    'sssiisssdi',
+    'sssiissssdi',
     $name,
     $species,
     $room,
     $watering_frequency,
     $fertilizing_frequency,
+    $plant_type,
     $last_watered,
     $last_fertilized,
     $photo_url,

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
             </div>
             <div>
                 <label for="plant_type" class="block mb-1">Plant Type <span class="required-star" aria-hidden="true">*</span></label>
-                <select id="plant_type" class="w-full border rounded-md p-2">
+                <select id="plant_type" name="plant_type" class="w-full border rounded-md p-2">
                     <option value="succulent">Succulent</option>
                     <option value="houseplant" selected>Houseplant</option>
                     <option value="vegetable">Vegetable</option>

--- a/migrations/003_add_plant_type.sql
+++ b/migrations/003_add_plant_type.sql
@@ -1,0 +1,3 @@
+-- Adds plant_type column to plants table to store the type/category of each plant
+ALTER TABLE plants
+    ADD COLUMN plant_type VARCHAR(50) NOT NULL DEFAULT 'houseplant';

--- a/script.js
+++ b/script.js
@@ -869,6 +869,9 @@ function populateForm(plant) {
   form.species.value = plant.species;
   showTaxonomyInfo(plant.species);
   form.watering_frequency.value = plant.watering_frequency;
+  if (form.plant_type) {
+    form.plant_type.value = plant.plant_type;
+  }
   if (form.water_amount) {
     const ml = parseFloat(plant.water_amount);
     if (ml > 0) {

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -84,12 +84,44 @@ class ApiTest extends TestCase
         $this->assertEquals('success', $data['status']);
     }
 
+    public function testAddPlantWithPlantType()
+    {
+        $_POST = [
+            'name' => 'Typed Plant',
+            'watering_frequency' => 5,
+            'plant_type' => 'cacti'
+        ];
+        ob_start();
+        include __DIR__ . '/../api/add_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('success', $data['status']);
+    }
+
     public function testUpdatePlantWithWaterAmount()
     {
         $_POST = [
             'id' => 1,
             'name' => 'Updated',
             'watering_frequency' => 7,
+            'water_amount' => 150,
+            'last_watered' => '',
+            'last_fertilized' => ''
+        ];
+        ob_start();
+        include __DIR__ . '/../api/update_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('success', $data['status']);
+    }
+
+    public function testUpdatePlantWithPlantType()
+    {
+        $_POST = [
+            'id' => 1,
+            'name' => 'Updated',
+            'watering_frequency' => 7,
+            'plant_type' => 'succulent',
             'water_amount' => 150,
             'last_watered' => '',
             'last_fertilized' => ''
@@ -146,6 +178,31 @@ class ApiTest extends TestCase
         $output = ob_get_clean();
         $data = json_decode($output, true);
         $this->assertEquals('success', $data['status']);
+    }
+
+    public function testGetPlantsIncludesPlantType()
+    {
+        global $mockQueryData;
+        $mockQueryData = [
+            [
+                'id' => 1,
+                'name' => 'Plant',
+                'species' => 'Plantus',
+                'watering_frequency' => 5,
+                'fertilizing_frequency' => 2,
+                'plant_type' => 'houseplant',
+                'room' => 'Kitchen',
+                'last_watered' => '2023-01-01',
+                'last_fertilized' => '2023-01-02',
+                'photo_url' => '',
+                'water_amount' => 0
+            ]
+        ];
+        ob_start();
+        include __DIR__ . '/../api/get_plants.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('houseplant', $data[0]['plant_type']);
     }
 }
 ?>

--- a/tests/db_stub.php
+++ b/tests/db_stub.php
@@ -7,6 +7,11 @@ if (!class_exists('MockStmt')) {
         public function fetch() { return false; }
         public function close() {}
     }
+    class MockResult {
+        private $data;
+        public function __construct($data) { $this->data = $data; }
+        public function fetch_assoc() { return array_shift($this->data); }
+    }
 }
 
 if (!class_exists('MockMysqli')) {
@@ -14,6 +19,10 @@ if (!class_exists('MockMysqli')) {
         public $connect_error = '';
         public function prepare($query) {
             return new MockStmt();
+        }
+        public function query($query) {
+            global $mockQueryData;
+            return new MockResult($mockQueryData ?? []);
         }
     }
 }


### PR DESCRIPTION
## Summary
- support selecting plant type in form
- store plant type in database
- expose plant type via APIs
- update JavaScript form handling for plant type
- extend unit tests and test DB stubs
- document new field and migration

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68607545dd6c8324a98d9eb6da3d038a