### PR TITLE
Add Cannabis sativa plant type

### DIFF
--- a/config.example.php
+++ b/config.example.php
@@ -11,6 +11,7 @@ return [
         'cacti'      => 0.28,
         'flower'     => 0.9,
         'citrus'     => 0.7,
+        'cannabis sativa' => 0.9,
     ],
     'bed_map' => [
         'vegetable' => [
@@ -26,6 +27,14 @@ return [
                 'ini' => 0.35,
                 'mid' => 1.1,
                 'end' => 1.0,
+            ],
+            'kc_soil' => 1.05,
+        ],
+        'cannabis sativa' => [
+            'kcb' => [
+                'ini' => 0.5,
+                'mid' => 0.9,
+                'end' => 1.1,
             ],
             'kc_soil' => 1.05,
         ],

--- a/config.php
+++ b/config.php
@@ -11,6 +11,7 @@ return [
         'cacti'      => 0.28,
         'flower'     => 0.9,
         'citrus'     => 0.7,
+        'cannabis sativa' => 0.9,
     ],
     'bed_map' => [
         'vegetable' => [
@@ -26,6 +27,14 @@ return [
                 'ini' => 0.35,
                 'mid' => 1.1,
                 'end' => 1.0,
+            ],
+            'kc_soil' => 1.05,
+        ],
+        'cannabis sativa' => [
+            'kcb' => [
+                'ini' => 0.5,
+                'mid' => 0.9,
+                'end' => 1.1,
             ],
             'kc_soil' => 1.05,
         ],

--- a/index.html
+++ b/index.html
@@ -64,7 +64,9 @@
                 <input type="hidden" name="photo_url" id="photo_url">
             </div>
             <div>
-                <label for="plant_type" class="block mb-1">Plant Type <span class="required-star" aria-hidden="true">*</span></label>
+                <label for="plant_type" class="block mb-1">Plant Type <span class="required-star" aria-hidden="true">*</span>
+                    <span class="help-icon" title="Hemp Kc ranges from 0.50 during early vegetative growth to 1.10 at full flowering" tabindex="0">?</span>
+                </label>
                 <select id="plant_type" class="w-full border rounded-md p-2">
                     <option value="succulent">Succulent</option>
                     <option value="houseplant" selected>Houseplant</option>
@@ -72,6 +74,7 @@
                     <option value="cacti">Cacti</option>
                     <option value="flower">Flower</option>
                     <option value="citrus">Citrus</option>
+                    <option value="cannabis sativa">Cannabis sativa</option>
                 </select>
             </div>
             <div>

--- a/script.js
+++ b/script.js
@@ -32,6 +32,7 @@ const KC_MAP = {
   cacti: 0.28,
   flower: 0.9,
   citrus: 0.7,
+  'cannabis sativa': 0.9,
 };
 
 let weatherTminC = null;
@@ -346,6 +347,7 @@ function updateWateringFrequency() {
   else if (type === 'vegetable') base = 3;
   else if (type === 'flower') base = 5;
   else if (type === 'citrus') base = 6;
+  else if (type === 'cannabis sativa') base = 3;
   let diam = parseFloat(potInput ? potInput.value : '');
   if (!isNaN(diam)) {
     const unit = unitSelect ? unitSelect.value : 'cm';


### PR DESCRIPTION
## Summary
- add Cannabis sativa to kc_map and bed_map
- show new option in plant type selector with tooltip
- support Cannabis kc in script constants and watering frequency

## Testing
- `phpunit -c phpunit.xml --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_6860760bfcf88324800c678977e54c22