### PR TITLE
Fix Tailwind plugin config and document local build

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ php -S localhost:8000
 ```
 Open `http://localhost:8000/index.html` in your browser to begin.
 
+## Building Tailwind Locally
+
+For production deployments you may prefer bundling Tailwind instead of loading it from the CDN. You can generate a minified build using the Tailwind CLI:
+
+```bash
+npm install -D tailwindcss @tailwindcss/forms
+npx tailwindcss -i ./style.css -o ./public/build/tailwind.css --minify
+```
+
+After generating the CSS, reference `public/build/tailwind.css` in `index.html` and remove the CDN script.
+
 ## Configuration
 
 Edit `config.php` and provide:

--- a/index.html
+++ b/index.html
@@ -22,8 +22,7 @@
               text: '#333333'
             }
           }
-        },
-        plugins: [tailwindcss.forms]
+        }
       }
     </script>
 </head>


### PR DESCRIPTION
## Summary
- remove CDN plugin object reference that caused errors
- document how to build Tailwind CSS locally for production

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68607c3d14e88324842a50d0ce086796