### PR TITLE
Improve DB error handling

### DIFF
--- a/db.php
+++ b/db.php
@@ -1,17 +1,33 @@
 <?php
-$host = "localhost"; // Leave this as is
-$user = "u568785491_jon"; // Your actual DB user
-$pass = "yS+olgrwgD1";  // ✅ Your new password
-$dbname = "u568785491_plants"; // Your actual DB name
+$host = getenv('DB_HOST') ?: 'localhost';
+$user = getenv('DB_USER') ?: 'u568785491_jon';
+$pass = getenv('DB_PASS') ?: 'yS+olgrwgD1';
+$dbname = getenv('DB_NAME') ?: 'u568785491_plants';
 
 $dbConfig = getenv('DB_CONFIG');
 if ($dbConfig && file_exists($dbConfig)) {
     include $dbConfig; // overrides $host, $user, $pass, $dbname if defined
 }
 
-$conn = new mysqli($host, $user, $pass, $dbname);
-if ($conn->connect_error) {
-    die("Connection failed: " . $conn->connect_error);
+$conn = null;
+mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+try {
+    $conn = new mysqli($host, $user, $pass, $dbname);
+    $conn->set_charset('utf8mb4');
+} catch (mysqli_sql_exception $e) {
+    error_log('Database connection failed: ' . $e->getMessage());
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    @http_response_code(500);
+    $response = ['error' => 'Database connection failed'];
+    if (getenv('DEBUG')) {
+        $response['details'] = $e->getMessage();
+    }
+    echo json_encode($response);
+    if (!getenv('TESTING')) {
+        exit;
+    }
 }
 ?>
 


### PR DESCRIPTION
## Summary
- support DB credentials via environment variables
- handle connection failures gracefully with JSON output and debug details

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68607c4050988324b961f726bb996d4b