### PR TITLE
Remove icons in text view summaries

### DIFF
--- a/style.css
+++ b/style.css
@@ -744,6 +744,15 @@ button:focus {
   color: #000;
 }
 
+#plant-grid.text-view .plant-summary .summary-item {
+  display: block;
+  grid-template-columns: 1fr;
+}
+
+#plant-grid.text-view .plant-summary .summary-item > span:first-child {
+  display: none;
+}
+
 #plant-grid .no-results {
   grid-column: 1 / -1;
   text-align: center;


### PR DESCRIPTION
## Summary
- hide icon spans inside summary items when viewing plants in text mode

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6860951a70188324b530b2281dbf8f8f