### PR TITLE
Fix plant type not persisting

### DIFF
--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -39,6 +39,7 @@ if (!preg_match($namePattern, $name)) {
     return;
 }
 $species = trim($_POST['species'] ?? '');
+$plant_type = isset($_POST['plant_type']) ? trim($_POST['plant_type']) : 'houseplant';
 $room = trim($_POST['room'] ?? '');
 $watering_frequency = intval($_POST['watering_frequency'] ?? 0);
 $fertilizing_frequency = intval($_POST['fertilizing_frequency'] ?? 0);
@@ -49,6 +50,9 @@ $photo_url = trim($_POST['photo_url'] ?? '');
 
 // further validation
 $errors = [];
+if (!in_array($plant_type, ['succulent', 'houseplant', 'vegetable', 'cacti'], true)) {
+    $errors[] = 'Invalid plant type';
+}
 if ($species !== '' && !preg_match("/^[\p{L}0-9\s.'-]{1,100}$/u", $species)) {
     $errors[] = 'Invalid species';
 }
@@ -98,6 +102,7 @@ $stmt = $conn->prepare(
     INSERT INTO plants (
         name,
         species,
+        plant_type,
         room,
         watering_frequency,
         fertilizing_frequency,
@@ -105,7 +110,7 @@ $stmt = $conn->prepare(
         last_fertilized,
         photo_url,
         water_amount
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 );
 if (!$stmt) {
     @http_response_code(500);
@@ -120,9 +125,10 @@ if (!$stmt) {
     return;
 }
 $stmt->bind_param(
-    "sssiisssd",
+    "ssssiisssd",
     $name,
     $species,
+    $plant_type,
     $room,
     $watering_frequency,
     $fertilizing_frequency,

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -17,7 +17,7 @@ if (!headers_sent()) {
 
 $plants = [];
 $result = $conn->query(
-    "SELECT id, name, species, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount
+    "SELECT id, name, species, plant_type, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount
     FROM plants
     ORDER BY id DESC"
 );

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -21,6 +21,7 @@ if (!headers_sent()) {
 $id                      = intval($_POST['id'] ?? 0);
 $name                    = trim($_POST['name'] ?? '');
 $species                 = trim($_POST['species'] ?? '');
+$plant_type              = isset($_POST['plant_type']) ? trim($_POST['plant_type']) : 'houseplant';
 $room                    = trim($_POST['room'] ?? '');
 $watering_frequency      = intval($_POST['watering_frequency'] ?? 0);
 $fertilizing_frequency   = intval($_POST['fertilizing_frequency'] ?? 0);
@@ -30,6 +31,9 @@ $last_fertilized         = $_POST['last_fertilized'] ?? null;
 $photo_url               = trim($_POST['photo_url'] ?? '');
 
 $errors = [];
+if (!in_array($plant_type, ['succulent', 'houseplant', 'vegetable', 'cacti'], true)) {
+    $errors[] = 'Invalid plant type';
+}
 $namePattern = "/^[\p{L}0-9\s'-]{1,100}$/u";
 if (!preg_match($namePattern, $name)) {
     $errors[] = 'Invalid name';
@@ -134,6 +138,7 @@ $stmt = $conn->prepare("
     UPDATE plants 
     SET name               = ?,
         species            = ?,
+        plant_type         = ?,
         room               = ?,
         watering_frequency = ?,
         fertilizing_frequency = ?,
@@ -144,9 +149,10 @@ $stmt = $conn->prepare("
     WHERE id = ?
 ");
 $stmt->bind_param(
-    'sssiisssdi',
+    'ssssiisssdi',
     $name,
     $species,
+    $plant_type,
     $room,
     $watering_frequency,
     $fertilizing_frequency,

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
             </div>
             <div>
                 <label for="plant_type" class="block mb-1">Plant Type <span class="required-star" aria-hidden="true">*</span></label>
-                <select id="plant_type" class="w-full border rounded-md p-2">
+                <select id="plant_type" name="plant_type" class="w-full border rounded-md p-2">
                     <option value="succulent">Succulent</option>
                     <option value="houseplant" selected>Houseplant</option>
                     <option value="vegetable">Vegetable</option>

--- a/migrations/003_add_plant_type.sql
+++ b/migrations/003_add_plant_type.sql
@@ -1,0 +1,3 @@
+-- Add plant_type column to store user-selected plant type
+ALTER TABLE plants
+    ADD COLUMN plant_type VARCHAR(20) NOT NULL DEFAULT 'houseplant';

--- a/script.js
+++ b/script.js
@@ -874,6 +874,7 @@ function populateForm(plant) {
   const form = document.getElementById('plant-form');
   form.name.value = plant.name;
   form.species.value = plant.species;
+  if (form.plant_type) form.plant_type.value = plant.plant_type || 'houseplant';
   showTaxonomyInfo(plant.species);
   form.watering_frequency.value = plant.watering_frequency;
   if (form.water_amount) {


### PR DESCRIPTION
## Summary
- allow plant type to be submitted with form
- store plant type when adding or editing plants
- expose plant type in API responses
- set plant type dropdown when editing
- add DB migration for plant_type column

## Testing
- `php -l api/add_plant.php`
- `php -l api/update_plant.php`
- `php -l api/get_plants.php`
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_6860a59c200c8324858cb5f233ffc617