### PR TITLE
Group calendar by room

### DIFF
--- a/script.js
+++ b/script.js
@@ -649,10 +649,34 @@ async function loadCalendar() {
     dayEls.push(dayEl);
   }
 
+  function getRoomGroup(dayEl, room) {
+    const safeRoom = room || 'Unassigned';
+    let group = dayEl.querySelector(`.room-group[data-room="${CSS.escape(safeRoom)}"]`);
+    if (!group) {
+      group = document.createElement('div');
+      group.classList.add('room-group');
+      group.dataset.room = safeRoom;
+      const header = document.createElement('div');
+      header.classList.add('room-header');
+      header.textContent = safeRoom;
+      header.style.backgroundColor = colorForRoom(room);
+      header.style.color = '#fff';
+      header.style.padding = '2px 6px';
+      header.style.borderRadius = '4px';
+      header.style.display = 'inline-block';
+      group.appendChild(header);
+      dayEl.appendChild(group);
+    }
+    return group;
+  }
+
   function addEvent(plant,type,date) {
     const dateStr = date.toISOString().split('T')[0];
     const dayEl = container.querySelector(`.cal-day[data-date="${dateStr}"]`);
     if (!dayEl) return;
+
+    const group = getRoomGroup(dayEl, plant.room);
+
     const ev = document.createElement('div');
     ev.classList.add('cal-event', type === 'water' ? 'water-due' : 'fert-due');
     ev.innerHTML =
@@ -664,7 +688,7 @@ async function loadCalendar() {
     ev.addEventListener('dragstart',e=>{
       e.dataTransfer.setData('text/plain', JSON.stringify({id:plant.id,type,date:dateStr}));
     });
-    dayEl.appendChild(ev);
+    group.appendChild(ev);
   }
 
   plants.forEach(p=>{

--- a/style.css
+++ b/style.css
@@ -597,6 +597,15 @@ button:focus {
   color: var(--color-plant);
 }
 
+#calendar .room-group {
+  margin-bottom: var(--spacing);
+}
+
+#calendar .room-header {
+  font-weight: 600;
+  margin: calc(var(--spacing) / 2) 0;
+}
+
 
 /* card layout */
 #plant-grid {


### PR DESCRIPTION
## Summary
- group calendar tasks by room
- add styles for room grouping

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6860ad2c456c832493ee255320b12906