### PR TITLE
Ensure water amount tags display on all screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -699,7 +699,6 @@ button:focus {
 
 /* text only view */
 #plant-grid.text-view .plant-photo,
-#plant-grid.text-view .tag-list,
 #plant-grid.text-view .actions {
   display: none;
 }
@@ -1106,11 +1105,7 @@ button:focus {
   color: var(--color-text);
 }
 
-@media (max-width: 500px) {
-  .plant-card .amt-tag {
-    display: none;
-  }
-}
+
 
 
 


### PR DESCRIPTION
## Summary
- remove small-screen CSS that hid water amount tags
- keep tag list visible in text view

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_686135b648d48324bdda29666c95bb6f