### PR TITLE
Fix plant type persistence

### DIFF
--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -40,6 +40,11 @@ if (!preg_match($namePattern, $name)) {
 }
 $species = trim($_POST['species'] ?? '');
 $room = trim($_POST['room'] ?? '');
+$plant_type = trim($_POST['plant_type'] ?? 'houseplant');
+$valid_types = ['succulent','houseplant','vegetable','cacti'];
+if (!in_array($plant_type, $valid_types, true)) {
+    $plant_type = 'houseplant';
+}
 $watering_frequency = intval($_POST['watering_frequency'] ?? 0);
 $fertilizing_frequency = intval($_POST['fertilizing_frequency'] ?? 0);
 $water_amount = isset($_POST['water_amount']) ? floatval($_POST['water_amount']) : 0;
@@ -98,6 +103,7 @@ $stmt = $conn->prepare(
     INSERT INTO plants (
         name,
         species,
+        plant_type,
         room,
         watering_frequency,
         fertilizing_frequency,
@@ -105,7 +111,7 @@ $stmt = $conn->prepare(
         last_fertilized,
         photo_url,
         water_amount
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 );
 if (!$stmt) {
     @http_response_code(500);
@@ -120,9 +126,10 @@ if (!$stmt) {
     return;
 }
 $stmt->bind_param(
-    "sssiisssd",
+    "ssssiisssd",
     $name,
     $species,
+    $plant_type,
     $room,
     $watering_frequency,
     $fertilizing_frequency,

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -17,7 +17,7 @@ if (!headers_sent()) {
 
 $plants = [];
 $result = $conn->query(
-    "SELECT id, name, species, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount
+    "SELECT id, name, species, plant_type, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount
     FROM plants
     ORDER BY id DESC"
 );

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -22,6 +22,11 @@ $id                      = intval($_POST['id'] ?? 0);
 $name                    = trim($_POST['name'] ?? '');
 $species                 = trim($_POST['species'] ?? '');
 $room                    = trim($_POST['room'] ?? '');
+$plant_type              = trim($_POST['plant_type'] ?? 'houseplant');
+$valid_types = ['succulent','houseplant','vegetable','cacti'];
+if (!in_array($plant_type, $valid_types, true)) {
+    $plant_type = 'houseplant';
+}
 $watering_frequency      = intval($_POST['watering_frequency'] ?? 0);
 $fertilizing_frequency   = intval($_POST['fertilizing_frequency'] ?? 0);
 $water_amount            = isset($_POST['water_amount']) ? floatval($_POST['water_amount']) : 0;
@@ -131,9 +136,10 @@ if (!$id) {
 
 // Prepare update statement
 $stmt = $conn->prepare("
-    UPDATE plants 
+    UPDATE plants
     SET name               = ?,
         species            = ?,
+        plant_type         = ?,
         room               = ?,
         watering_frequency = ?,
         fertilizing_frequency = ?,
@@ -144,9 +150,10 @@ $stmt = $conn->prepare("
     WHERE id = ?
 ");
 $stmt->bind_param(
-    'sssiisssdi',
+    'ssssiisssdi',
     $name,
     $species,
+    $plant_type,
     $room,
     $watering_frequency,
     $fertilizing_frequency,

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
             </div>
             <div>
                 <label for="plant_type" class="block mb-1">Plant Type <span class="required-star" aria-hidden="true">*</span></label>
-                <select id="plant_type" class="w-full border rounded-md p-2">
+                <select id="plant_type" name="plant_type" class="w-full border rounded-md p-2">
                     <option value="succulent">Succulent</option>
                     <option value="houseplant" selected>Houseplant</option>
                     <option value="vegetable">Vegetable</option>

--- a/migrations/003_add_plant_type.sql
+++ b/migrations/003_add_plant_type.sql
@@ -1,0 +1,3 @@
+-- Add plant_type column for tracking type of plant
+ALTER TABLE plants
+    ADD COLUMN plant_type VARCHAR(20) NOT NULL DEFAULT 'houseplant';

--- a/script.js
+++ b/script.js
@@ -758,6 +758,7 @@ async function updatePlantInline(plant, field, newValue) {
   data.append('id', plant.id);
   data.append('name', plant.name);
   data.append('species', plant.species);
+  data.append('plant_type', plant.plant_type || 'houseplant');
   data.append('watering_frequency', plant.watering_frequency);
   data.append('fertilizing_frequency', plant.fertilizing_frequency);
   data.append('water_amount', plant.water_amount);
@@ -790,6 +791,7 @@ async function updatePlantPhoto(plant, file) {
   data.append('id', plant.id);
   data.append('name', plant.name);
   data.append('species', plant.species);
+  data.append('plant_type', plant.plant_type || 'houseplant');
   data.append('watering_frequency', plant.watering_frequency);
   data.append('fertilizing_frequency', plant.fertilizing_frequency);
   data.append('water_amount', plant.water_amount);
@@ -892,6 +894,8 @@ function populateForm(plant) {
   form.species.value = plant.species;
   showTaxonomyInfo(plant.species);
   form.watering_frequency.value = plant.watering_frequency;
+  const typeSelect = document.getElementById('plant_type');
+  if (typeSelect) typeSelect.value = plant.plant_type || 'houseplant';
   if (form.water_amount) {
     const ml = parseFloat(plant.water_amount);
     if (ml > 0) {


### PR DESCRIPTION
## Summary
- include `plant_type` in all inline update requests so the value isn't overwritten by PHP defaults

## Testing
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68613573b94c83249ebf7821e6c26976