### PR TITLE
Hide plant card icons in text view

### DIFF
--- a/style.css
+++ b/style.css
@@ -733,6 +733,12 @@ button:focus {
   padding: 0;
 }
 
+/* hide all images and icons in text mode */
+#plant-grid.text-view .plant-card img,
+#plant-grid.text-view .plant-card svg {
+  display: none;
+}
+
 
 #plant-grid .no-results {
   grid-column: 1 / -1;


### PR DESCRIPTION
## Summary
- ensure no icons or images display in plant cards when in text view

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686140f48dbc8324b474805715047088