### PR TITLE
Hide empty room groups in calendar

### DIFF
--- a/script.js
+++ b/script.js
@@ -694,6 +694,13 @@ async function loadCalendar() {
     if (f) addEvent(p,'fert',f);
   });
 
+  // Remove room groups that have no events
+  groupMap.forEach(group => {
+    if (group.querySelectorAll('.cal-event').length === 0) {
+      group.remove();
+    }
+  });
+
 }
 
 


### PR DESCRIPTION
## Summary
- clean up calendar rendering by removing room sections without events

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68614198a9d08324b8a50b8fdf8ed85a