### PR TITLE
Fix text view gap

### DIFF
--- a/style.css
+++ b/style.css
@@ -749,6 +749,12 @@ button:focus {
   padding: 0;
 }
 
+/* remove icon spacing when in text view */
+#plant-grid.text-view .plant-summary .summary-item {
+  grid-template-columns: 1fr;
+  column-gap: 0;
+}
+
 /* hide all images and icons in text mode */
 #plant-grid.text-view .plant-card img,
 #plant-grid.text-view .plant-card svg {


### PR DESCRIPTION
## Summary
- remove extra margin for summary items when in text view so text lines up on the left

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68614458e94883248e733abb02d41599