### PR TITLE
Remove schedule heading in text view

### DIFF
--- a/style.css
+++ b/style.css
@@ -733,6 +733,9 @@ button:focus {
 #plant-grid.text-view .water-warning {
   display: none;
 }
+#plant-grid.text-view .schedule-heading {
+  display: none;
+}
 #plant-grid.text-view .plant-title {
   font-size: 1rem;
   margin: 0;


### PR DESCRIPTION
## Summary
- hide the schedule heading when viewing plants in text-only mode

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6861461d66cc83249236ff295c95f6cf