### PR TITLE
Improve calendar responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,12 +182,11 @@
     <div id="plant-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 p-4"></div>
 
 
-    <h2 id="calendar-heading" class="text-xl font-semibold p-4 flex items-center">Upcoming Tasks
-        <span class="ml-auto flex gap-2">
-            <button id="prev-week" class="bg-primary text-white rounded-md px-4 py-2"></button>
-            <button id="next-week" class="bg-primary text-white rounded-md px-4 py-2"></button>
-        </span>
-    </h2>
+    <h2 id="calendar-heading" class="text-xl font-semibold p-4">Upcoming Tasks</h2>
+    <div id="calendar-nav" class="flex justify-end gap-2 px-4 pb-2">
+        <button id="prev-week" class="bg-primary text-white rounded-md px-4 py-2"></button>
+        <button id="next-week" class="bg-primary text-white rounded-md px-4 py-2"></button>
+    </div>
     <div id="calendar" class="p-4"></div>
 
     <script>

--- a/style.css
+++ b/style.css
@@ -555,6 +555,36 @@ button:focus {
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: calc(var(--spacing) * 2);
   margin-top: calc(var(--spacing) * 2);
+  overflow-x: auto;
+  scroll-behavior: smooth;
+}
+
+#calendar-nav {
+  display: flex;
+  justify-content: flex-end;
+  gap: calc(var(--spacing));
+  padding: 0 calc(var(--spacing) * 2) calc(var(--spacing));
+}
+
+@media (max-width: 640px) {
+  #calendar-nav {
+    display: none;
+  }
+  #calendar {
+    display: flex;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+  }
+  #calendar .cal-day {
+    flex: 0 0 80%;
+    scroll-snap-align: start;
+  }
+}
+
+@media (min-width: 1200px) {
+  #calendar {
+    grid-template-columns: repeat(7, 1fr);
+  }
 }
 
 #calendar.hidden {
@@ -562,10 +592,11 @@ button:focus {
 }
 
 #calendar .cal-day {
-  background: var(--color-surface);
+  background: #fff;
   border: 1px solid var(--color-border);
-  border-radius: var(--radius);
-  padding: var(--spacing);
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  padding: 1rem;
   min-height: 140px;
   display: flex;
   flex-direction: column;
@@ -573,7 +604,8 @@ button:focus {
 
 
 #calendar .cal-day-header {
-  font-weight: 600;
+  font-weight: 700;
+  font-size: 1.1rem;
   margin-bottom: calc(var(--spacing));
   padding-bottom: calc(var(--spacing) / 2);
   border-bottom: 1px solid var(--color-border);
@@ -587,6 +619,11 @@ button:focus {
   cursor: move;
   box-shadow: 0 1px 2px rgba(0,0,0,0.1);
   border-left: 4px solid transparent;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+  line-height: 1.5;
 }
 
 #calendar .cal-event.water-due {


### PR DESCRIPTION
## Summary
- make calendar scroll horizontally on small screens
- move week navigation below heading and hide on mobile
- style calendar cards with padding, shadow and flex icons

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68614775dd08832483a9a910986e4880