### PR TITLE
Enable tags in text view

### DIFF
--- a/style.css
+++ b/style.css
@@ -773,10 +773,24 @@ button:focus {
   border-radius: 0;
   box-shadow: none;
 }
-#plant-grid.text-view .tag-list,
 #plant-grid.text-view .urgency-tag,
 #plant-grid.text-view .water-warning {
   display: none;
+}
+
+#plant-grid.text-view .tag-list {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+}
+
+#plant-grid.text-view .tag-list .tag {
+  background: none;
+  color: inherit;
+  padding: 0;
+  border: none;
+  font-weight: 400;
+  margin-right: 0.5rem;
 }
 #plant-grid.text-view .schedule-heading {
   display: none;


### PR DESCRIPTION
## Summary
- show tag info when the text-only view is active
- keep title, species, and summary styling for text view

## Testing
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6861513922e883249ecb6b0b2f8f0586