### PR TITLE
Enable swipe completion in list view

### DIFF
--- a/script.js
+++ b/script.js
@@ -743,6 +743,25 @@ async function markAction(id, type, days = 0) {
   }
 }
 
+function setupSwipe(card, plant, waterDue, fertDue) {
+  let startX = 0;
+  let startY = 0;
+  card.addEventListener('touchstart', e => {
+    const t = e.touches[0];
+    startX = t.clientX;
+    startY = t.clientY;
+  });
+  card.addEventListener('touchend', e => {
+    const t = e.changedTouches[0];
+    const dx = t.clientX - startX;
+    const dy = t.clientY - startY;
+    if (dx > 80 && Math.abs(dy) < 40) {
+      if (waterDue) markAction(plant.id, 'watered');
+      if (fertDue) markAction(plant.id, 'fertilized');
+    }
+  });
+}
+
 // --- undo-delete snackbar ---
 function showUndoBanner(plant) {
   lastDeletedPlant = plant;
@@ -1292,7 +1311,8 @@ async function loadPlants() {
     const waterDue = needsWatering(plant, today);
     const fertDue = needsFertilizing(plant, today);
 
-    if (waterDue) {
+    const showButtons = viewMode !== 'list';
+    if (waterDue && showButtons) {
       const btn = document.createElement('button');
       btn.classList.add('action-btn', 'due-task', 'water-due');
       btn.innerHTML = ICONS.water + '<span class="visually-hidden">Water</span>';
@@ -1323,7 +1343,7 @@ async function loadPlants() {
       actionsDiv.appendChild(snooze);
     }
 
-    if (fertDue) {
+    if (fertDue && showButtons) {
       const btn = document.createElement('button');
       btn.classList.add('action-btn', 'due-task', 'fert-due');
       btn.innerHTML = ICONS.fert + '<span class="visually-hidden">Fertilize</span>';
@@ -1430,6 +1450,9 @@ async function loadPlants() {
     card.appendChild(actionsDiv);
 
     list.appendChild(card);
+    if (viewMode === 'list') {
+      setupSwipe(card, plant, waterDue, fertDue);
+    }
   });
 
   // refresh room filter and datalist


### PR DESCRIPTION
## Summary
- implement `setupSwipe` helper that marks due tasks when card swiped right
- hide quick action buttons when in list view
- attach swipe handler to list cards

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686156032a68832492ea0ed7163b4512