### PR TITLE
Reload plants on view change

### DIFF
--- a/script.js
+++ b/script.js
@@ -1848,6 +1848,7 @@ function init(){
       btn.addEventListener('click', () => {
         viewMode = btn.dataset.view;
         applyViewMode();
+        loadPlants();
       });
     });
     applyViewMode();


### PR DESCRIPTION
## Summary
- when switching view modes, reload the plant cards to reflect the layout change

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6861612e97c48324acfbbe5694aeaffe