### PR TITLE
Add mark controls to overflow menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ Both rely on the coefficients defined in `config.php`.
 ## Basic Usage
 
 Use the main interface at `index.html` to add plants, mark them as watered or
-fertilized, and upload photos. The API endpoints under `api/` are used by the
-front‑end JavaScript (`script.js`) to interact with the database.
+fertilized, and upload photos. When a plant has a watering or fertilizing task
+due, the overflow menu on each card now includes **Mark Watered** and **Mark
+Fertilized** options so the actions remain available even in list view. The API
+endpoints under `api/` are used by the front‑end JavaScript (`script.js`) to
+interact with the database.
 
 

--- a/script.js
+++ b/script.js
@@ -1429,7 +1429,8 @@ async function loadPlants() {
 
     const changeBtn = document.createElement('button');
     changeBtn.classList.add('action-btn', 'photo-btn');
-    changeBtn.innerHTML = ICONS.photo + '<span class="visually-hidden">Change Photo</span>';
+    changeBtn.innerHTML =
+      ICONS.photo + '<span class="visually-hidden">Change Photo</span>';
     changeBtn.type = 'button';
     changeBtn.title = 'Add Image';
     changeBtn.onclick = () => {
@@ -1437,6 +1438,34 @@ async function loadPlants() {
       menu.classList.remove('show');
     };
     menu.appendChild(changeBtn);
+
+    if (waterDue) {
+      const waterMenuBtn = document.createElement('button');
+      waterMenuBtn.classList.add('action-btn', 'water-due');
+      waterMenuBtn.innerHTML =
+        ICONS.water + '<span class="visually-hidden">Mark Watered</span>';
+      waterMenuBtn.title = 'Mark Watered';
+      waterMenuBtn.type = 'button';
+      waterMenuBtn.onclick = () => {
+        markAction(plant.id, 'watered');
+        menu.classList.remove('show');
+      };
+      menu.appendChild(waterMenuBtn);
+    }
+
+    if (fertDue) {
+      const fertMenuBtn = document.createElement('button');
+      fertMenuBtn.classList.add('action-btn', 'fert-due');
+      fertMenuBtn.innerHTML =
+        ICONS.fert + '<span class="visually-hidden">Mark Fertilized</span>';
+      fertMenuBtn.title = 'Mark Fertilized';
+      fertMenuBtn.type = 'button';
+      fertMenuBtn.onclick = () => {
+        markAction(plant.id, 'fertilized');
+        menu.classList.remove('show');
+      };
+      menu.appendChild(fertMenuBtn);
+    }
 
     menuBtn.onclick = (e) => {
       e.stopPropagation();

--- a/style.css
+++ b/style.css
@@ -927,6 +927,12 @@ button:focus {
   gap: var(--spacing);
 }
 
+.overflow-menu .action-btn {
+  width: 100%;
+  justify-content: flex-start;
+  padding: calc(var(--spacing) / 2);
+}
+
 .overflow-menu.show {
   display: flex;
 }


### PR DESCRIPTION
## Summary
- add "Mark Watered" and "Mark Fertilized" items to card overflow menu
- widen overflow menu buttons for easier keyboard use
- document new menu options in README

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6861613a49688324bf1a18a7fcafe7d6