### PR TITLE
Add flower plant type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ water requirements using local weather data.
     'succulent'  => 0.3,
     'houseplant' => 0.8,
     'vegetable'  => 1.0,
+    'flower'     => 0.9,
     'cacti'      => 0.28,
 ],
 'bed_map' => [

--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -41,7 +41,7 @@ if (!preg_match($namePattern, $name)) {
 $species = trim($_POST['species'] ?? '');
 $room = trim($_POST['room'] ?? '');
 $plant_type = trim($_POST['plant_type'] ?? 'houseplant');
-$valid_types = ['succulent','houseplant','vegetable','cacti'];
+$valid_types = ['succulent','houseplant','vegetable','flower','cacti'];
 if (!in_array($plant_type, $valid_types, true)) {
     $plant_type = 'houseplant';
 }

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -23,7 +23,7 @@ $name                    = trim($_POST['name'] ?? '');
 $species                 = trim($_POST['species'] ?? '');
 $room                    = trim($_POST['room'] ?? '');
 $plant_type              = trim($_POST['plant_type'] ?? 'houseplant');
-$valid_types = ['succulent','houseplant','vegetable','cacti'];
+$valid_types = ['succulent','houseplant','vegetable','flower','cacti'];
 if (!in_array($plant_type, $valid_types, true)) {
     $plant_type = 'houseplant';
 }

--- a/config.example.php
+++ b/config.example.php
@@ -8,6 +8,7 @@ return [
         'succulent'  => 0.3,
         'houseplant' => 0.8,
         'vegetable'  => 1.0,
+        'flower'     => 0.9,
         'cacti'      => 0.28,
     ],
     'bed_map' => [

--- a/config.php
+++ b/config.php
@@ -8,6 +8,7 @@ return [
         'succulent'  => 0.3,
         'houseplant' => 0.8,
         'vegetable'  => 1.0,
+        'flower'     => 0.9,
         'cacti'      => 0.28,
     ],
     'bed_map' => [

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
                     <option value="succulent">Succulent</option>
                     <option value="houseplant" selected>Houseplant</option>
                     <option value="vegetable">Vegetable</option>
+                    <option value="flower">Flower</option>
                     <option value="cacti">Cacti</option>
                 </select>
             </div>

--- a/script.js
+++ b/script.js
@@ -27,6 +27,7 @@ const KC_MAP = {
   succulent: 0.3,
   houseplant: 0.8,
   vegetable: 1.0,
+  flower: 0.9,
   cacti: 0.28,
 };
 
@@ -339,6 +340,7 @@ function updateWateringFrequency() {
   const type = typeSelect ? typeSelect.value : 'houseplant';
   if (type === 'succulent') base = 14;
   else if (type === 'cacti') base = 21;
+  else if (type === 'flower') base = 5;
   else if (type === 'vegetable') base = 3;
   let diam = parseFloat(potInput ? potInput.value : '');
   if (!isNaN(diam)) {


### PR DESCRIPTION
## Summary
- add `flower` to the plant type dropdown
- include crop coefficient for flowers in configs and JS
- allow flower type in API input validation
- tweak watering frequency heuristic for flowers

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68619b5de7988324ba5cf569bae5eb60