### PR TITLE
Enable swipe completion in text view

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,7 @@ Use the main interface at `index.html` to add plants, mark them as watered or
 fertilized, and upload photos. The API endpoints under `api/` are used by the
 front‑end JavaScript (`script.js`) to interact with the database.
 
+In list or text view you can swipe right on a plant card to complete all due
+tasks (watering and fertilizing) at once.
+
 

--- a/script.js
+++ b/script.js
@@ -1453,7 +1453,7 @@ async function loadPlants() {
     actionsDiv.appendChild(fileInput);
     card.appendChild(actionsDiv);
 
-    if (viewMode === 'list') {
+    if (viewMode === 'list' || viewMode === 'text') {
       enableSwipeComplete(card, plant, waterDue, fertDue);
     }
 


### PR DESCRIPTION
## Summary
- allow swiping right in text view to mark tasks complete
- document swipe-to-complete in README

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686199a154f083248fd4711d6ebca210