### PR TITLE
Add plant type sorting option

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
         <select id="sort-toggle" class="border rounded-md">
             <option value="name">Sort by: Name</option>
             <option value="due" selected>Sort by: Due Date</option>
+            <option value="type">Sort by: Plant Type</option>
         </select>
         <select id="due-filter" class="border rounded-md">
             <option value="all">Show: All</option>

--- a/script.js
+++ b/script.js
@@ -1160,11 +1160,15 @@ async function loadPlants() {
   summaryEl.classList.add('show');
 
   const sortBy = document.getElementById('sort-toggle').value || 'name';
-  filtered.sort((a, b) =>
-    sortBy === 'due'
-      ? getSoonestDueDate(a) - getSoonestDueDate(b)
-      : a.name.localeCompare(b.name)
-  );
+  filtered.sort((a, b) => {
+    if (sortBy === 'due') {
+      return getSoonestDueDate(a) - getSoonestDueDate(b);
+    }
+    if (sortBy === 'type') {
+      return (a.plant_type || '').localeCompare(b.plant_type || '');
+    }
+    return a.name.localeCompare(b.name);
+  });
 
   filtered.forEach(plant => {
     const card = document.createElement('div');


### PR DESCRIPTION
## Summary
- extend sort dropdown with `Plant Type`
- allow sorting by plant type in script

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68619de10cbc832485d40ccb430b6773