### PR TITLE
Improve swipe completion reliability

### DIFF
--- a/script.js
+++ b/script.js
@@ -751,10 +751,14 @@ function enableSwipeComplete(card, plant, waterDue, fertDue) {
   let startX = null;
   let startY = null;
   let swiping = false;
+  let activePointerId = null;
   card.addEventListener('pointerdown', e => {
+    e.preventDefault();
     startX = e.clientX;
     startY = e.clientY;
     swiping = false;
+    activePointerId = e.pointerId;
+    card.setPointerCapture(activePointerId);
     card.style.transition = 'none';
   });
   card.addEventListener('pointermove', e => {
@@ -786,12 +790,20 @@ function enableSwipeComplete(card, plant, waterDue, fertDue) {
       card.style.transform = '';
     }
     swiping = false;
+    if (activePointerId !== null) {
+      card.releasePointerCapture(activePointerId);
+      activePointerId = null;
+    }
   });
   card.addEventListener('pointercancel', () => {
     startX = startY = null;
     swiping = false;
     card.style.transition = '';
     card.style.transform = '';
+    if (activePointerId !== null) {
+      card.releasePointerCapture(activePointerId);
+      activePointerId = null;
+    }
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -865,6 +865,7 @@ button:focus {
   box-shadow: 0 1px 2px rgba(0,0,0,0.05);
   transition: box-shadow 0.2s, transform 0.2s;
   touch-action: pan-y; /* allow horizontal swipe gestures */
+  user-select: none;
 }
 
 .plant-card:hover {


### PR DESCRIPTION
## Summary
- keep pointer capture on swipe start so swipe tracking continues when the pointer leaves the card
- release pointer capture on pointer up or cancel
- prevent text selection during swipe by disabling user select on plant cards

## Testing
- `phpunit -v`

------
https://chatgpt.com/codex/tasks/task_e_6861fbc5525c83248e301c32bd4731a9