### PR TITLE
Add tests for archived filter

### DIFF
--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -147,5 +147,22 @@ class ApiTest extends TestCase
         $data = json_decode($output, true);
         $this->assertEquals('success', $data['status']);
     }
+
+    public function testGetPlantsArchivedFilter()
+    {
+        $_GET['archived'] = 'true';
+        ob_start();
+        include __DIR__ . '/../api/get_plants.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertIsArray($data);
+
+        $_GET['archived'] = 'false';
+        ob_start();
+        include __DIR__ . '/../api/get_plants.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertIsArray($data);
+    }
 }
 ?>

--- a/tests/db_stub.php
+++ b/tests/db_stub.php
@@ -9,11 +9,21 @@ if (!class_exists('MockStmt')) {
     }
 }
 
+if (!class_exists('MockResult')) {
+    class MockResult {
+        public $error = '';
+        public function fetch_assoc() { return false; }
+    }
+}
+
 if (!class_exists('MockMysqli')) {
     class MockMysqli {
         public $connect_error = '';
         public function prepare($query) {
             return new MockStmt();
+        }
+        public function query($query) {
+            return new MockResult();
         }
     }
 }

--- a/tests/db_stub_fail.php
+++ b/tests/db_stub_fail.php
@@ -4,6 +4,9 @@ class FailMysqli {
     public function prepare($query) {
         return false; // simulate failure
     }
+    public function query($query) {
+        return false; // simulate failure
+    }
 }
 
 $conn = new FailMysqli();


### PR DESCRIPTION
## Summary
- extend DB stubs with a simple query interface
- test that `get_plants.php` handles the `archived` parameter for active vs archived views

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686289d72c2083248d754ae5ecc9804d