### PR TITLE
Restore backend support for archived plants

### DIFF
--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -15,10 +15,13 @@ if (!headers_sent()) {
     header('Content-Type: application/json');
 }
 
+$arch = (isset($_GET['archived']) && $_GET['archived'] === 'true') ? 1 : 0;
+
 $plants = [];
 $result = $conn->query(
-    "SELECT id, name, species, plant_type, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount
+    "SELECT id, name, species, plant_type, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount, archived
     FROM plants
+    WHERE archived = {$arch}
     ORDER BY id DESC"
 );
 if (!$result) {

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -33,6 +33,7 @@ $water_amount            = isset($_POST['water_amount']) ? floatval($_POST['wate
 $last_watered            = $_POST['last_watered'] ?? null;
 $last_fertilized         = $_POST['last_fertilized'] ?? null;
 $photo_url               = trim($_POST['photo_url'] ?? '');
+$archived                = isset($_POST['archived']) && intval($_POST['archived']) === 1 ? 1 : 0;
 
 $errors = [];
 $namePattern = "/^[\p{L}0-9\s'-]{1,100}$/u";
@@ -146,11 +147,12 @@ $stmt = $conn->prepare("
         last_watered       = ?,
         last_fertilized    = ?,
         photo_url          = ?,
-        water_amount       = ?
+        water_amount       = ?,
+        archived           = ?
     WHERE id = ?
 ");
 $stmt->bind_param(
-    'ssssiisssdi',
+    'ssssiisssdii',
     $name,
     $species,
     $plant_type,
@@ -161,6 +163,7 @@ $stmt->bind_param(
     $last_fertilized,
     $photo_url,
     $water_amount,
+    $archived,
     $id
 );
 

--- a/migrations/004_add_archived_column.sql
+++ b/migrations/004_add_archived_column.sql
@@ -1,0 +1,3 @@
+-- Add archived column to track inactive plants
+ALTER TABLE plants
+    ADD COLUMN archived TINYINT(1) NOT NULL DEFAULT 0;

--- a/script.js
+++ b/script.js
@@ -906,6 +906,7 @@ async function updatePlantInline(plant, field, newValue) {
   data.append('last_watered', plant.last_watered || '');
   data.append('last_fertilized', plant.last_fertilized || '');
   data.append('photo_url', plant.photo_url || '');
+  data.append('archived', plant.archived ? 1 : 0);
 
   data.set(field, newValue);
 
@@ -938,6 +939,7 @@ async function updatePlantPhoto(plant, file) {
   data.append('room', plant.room);
   data.append('last_watered', plant.last_watered || '');
   data.append('last_fertilized', plant.last_fertilized || '');
+  data.append('archived', plant.archived ? 1 : 0);
   data.append('photo', file);
 
   toggleLoading(true);


### PR DESCRIPTION
## Summary
- add a database migration for an `archived` column
- filter `get_plants.php` by the archived flag
- allow `update_plant.php` to update the flag
- send the archived state from the front-end when updating plants

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6862d3ca2a108324a8969db13c9e94a7