### PR TITLE
Add plant archiving option

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,7 @@
             <button type="button" data-view="text" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
         </div>
     </div>
+    <p id="archived-link" class="text-sm px-4 hidden"></p>
     <div id="rainfall-info" class="p-4 bg-card rounded-lg mb-4 hidden"></div>
 
     <!-- Undo delete snackbar -->

--- a/migrations/004_add_archived.sql
+++ b/migrations/004_add_archived.sql
@@ -1,0 +1,3 @@
+-- Add archived column to allow soft deletion
+ALTER TABLE plants
+    ADD COLUMN archived TINYINT(1) NOT NULL DEFAULT 0;

--- a/style.css
+++ b/style.css
@@ -1270,6 +1270,29 @@ button:focus {
   color: var(--color-text);
 }
 
+.plant-card.archived {
+  opacity: 0.6;
+}
+.plant-card.archived::after {
+  content: 'Archived';
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+}
+
+#archived-link {
+  cursor: pointer;
+  color: var(--color-primary);
+  text-decoration: underline;
+  display: none;
+}
+#archived-link.hidden { display: none; }
+
 
 
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -147,5 +147,25 @@ class ApiTest extends TestCase
         $data = json_decode($output, true);
         $this->assertEquals('success', $data['status']);
     }
+
+    public function testArchivePlantMissingId()
+    {
+        $_POST = [];
+        ob_start();
+        include __DIR__ . '/../api/archive_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('error', $data['status']);
+    }
+
+    public function testArchivePlantSuccess()
+    {
+        $_POST = ['id' => 1, 'archive' => 1];
+        ob_start();
+        include __DIR__ . '/../api/archive_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('success', $data['status']);
+    }
 }
 ?>


### PR DESCRIPTION
## Summary
- allow fetching archived plants via API parameter
- add API endpoint to toggle archived state
- show link to archived plants when a room contains them
- support archiving and restoring from plant card menu
- style archived plant cards
- test archiving API

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6862e08987bc8324a80639aaf05fd9a6