### PR TITLE
Fix archived link display

### DIFF
--- a/style.css
+++ b/style.css
@@ -1290,7 +1290,7 @@ button:focus {
   cursor: pointer;
   color: var(--color-primary);
   text-decoration: underline;
-  display: none;
+  display: inline;
 }
 #archived-link.hidden { display: none; }
 


### PR DESCRIPTION
## Summary
- show the archived link by default
- keep `.hidden` class controlling visibility

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6862e91fb3f883248a7234191968cd92