### PR TITLE
Add archive button styling and count

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
             <button type="button" data-view="text" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
         </div>
     </div>
-    <p id="archived-link" class="text-sm px-4 hidden"></p>
+    <button id="archived-link" type="button" class="text-sm hidden"></button>
     <div id="rainfall-info" class="p-4 bg-card rounded-lg mb-4 hidden"></div>
 
     <!-- Undo delete snackbar -->

--- a/script.js
+++ b/script.js
@@ -1756,9 +1756,9 @@ async function checkArchivedLink(plantsList) {
     const res = await fetch('api/get_plants.php?archived=1');
     archivedCache = await res.json();
   }
-  const has = archivedCache.some(p => p.room === room);
-  if (has) {
-    link.textContent = 'Archived plants';
+  const count = archivedCache.filter(p => p.room === room).length;
+  if (count > 0) {
+    link.innerHTML = ICONS.archive + ` Archived (${count})`;
     link.classList.remove('hidden');
   } else {
     link.classList.add('hidden');

--- a/style.css
+++ b/style.css
@@ -1335,10 +1335,24 @@ button:focus {
 }
 
 #archived-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   cursor: pointer;
-  color: var(--color-primary);
-  text-decoration: underline;
-  display: inline;
+  font-size: 0.875rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-card);
+  color: var(--color-text);
+  transition: background-color 0.2s, border-color 0.2s, color 0.2s;
+}
+#archived-link:hover {
+  border-color: var(--color-primary);
+}
+#archived-link:active {
+  background: var(--color-primary);
+  color: var(--color-surface);
 }
 #archived-link.hidden { display: none; }
 


### PR DESCRIPTION
## Summary
- change archived link to button in the interface
- style the button with borders, hover, and active states
- display archive icon and count via JS

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6863306040508324918c58ce12c93dc8