### PR TITLE
Improve readability of text view

### DIFF
--- a/style.css
+++ b/style.css
@@ -739,7 +739,8 @@ button:focus {
 #plant-grid.text-view {
   display: flex;
   flex-direction: column;
-  gap: calc(var(--spacing) * 1.5);
+  /* use separators rather than spacing between entries */
+  gap: 0;
   max-width: 48rem;
   margin-left: 0;
   margin-right: auto;
@@ -811,7 +812,7 @@ button:focus {
 
 #plant-grid.text-view .plant-card {
   display: block;
-  padding-bottom: calc(var(--spacing) * 1.5);
+  padding: calc(var(--spacing) * 1.5) 0;
   margin: 0;
   background: none;
   border: none;


### PR DESCRIPTION
## Summary
- use zero gap for text view and rely on border separators
- pad text view cards evenly to keep spacing

## Testing
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_686337e74f108324b50bd91ddea02e3f