### PR TITLE
Improve text-view separator visibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,7 +8,7 @@
  --color-card: #ffffff;
  --color-surface: #ffffff;
 
---color-border: #c8e6c9; 
+ --color-border: #a5d6a7;
 
 --color-text: #2e3a29; 
 


### PR DESCRIPTION
## Summary
- darken the default border color to show separators in text mode better

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68633cd64b2883249ddc9447056458b6