### PR TITLE
Add ET₀ horizon chart

### DIFF
--- a/script.js
+++ b/script.js
@@ -201,6 +201,52 @@ function hexToRgb(hex) {
     b: num & 255
   };
 }
+
+function initEt0Sparkline(canvas) {
+  const plantId = canvas.dataset.plantId;
+  if (!plantId) return;
+  fetch(`api/get_et0_timeseries.php?plant_id=${plantId}&days=7`)
+    .then(r => r.json())
+    .then(data => {
+      const et0 = data.map(d => parseFloat(d.et0_mm));
+      canvas.title = 'ET\u2080 last 7 days';
+      const ctx = canvas.getContext('2d');
+      const accentHex =
+        getComputedStyle(document.documentElement).getPropertyValue(
+          '--color-accent'
+        ) || '#228b22';
+      const color = hexToRgb(accentHex);
+
+      const bandSize = 2;
+      const maxVal = Math.max(...et0, bandSize);
+      const bands = Math.ceil(maxVal / bandSize);
+      const bandHeight = canvas.height / bands;
+      const step = canvas.width / et0.length;
+
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      for (let b = bands; b >= 1; b--) {
+        ctx.beginPath();
+        ctx.moveTo(0, canvas.height - bandHeight * b);
+        et0.forEach((v, i) => {
+          const capped = Math.min(
+            Math.max(v - bandSize * (b - 1), 0),
+            bandSize
+          );
+          const y =
+            canvas.height - bandHeight * b +
+            bandHeight - (capped / bandSize) * bandHeight;
+          ctx.lineTo(i * step, y);
+        });
+        ctx.lineTo(canvas.width, canvas.height - bandHeight * b);
+        ctx.closePath();
+        const alpha = 0.4 + (0.6 * b) / bands;
+        ctx.fillStyle = `rgba(${color.r},${color.g},${color.b},${alpha})`;
+        ctx.fill();
+      }
+    })
+    .catch(() => {});
+}
 async function fetchScientificNames(query) {
   if (!query) return [];
   if (speciesKeyCache.has(`s:${query}`)) return speciesKeyCache.get(`s:${query}`);
@@ -1475,8 +1521,23 @@ async function loadPlants() {
       tagList.appendChild(amtTag);
     }
 
+    const meta = document.createElement('div');
+    meta.classList.add('card-meta');
     if (tagList.childElementCount > 0) {
-      infoWrap.appendChild(tagList);
+      meta.appendChild(tagList);
+    }
+    if (viewMode === 'grid') {
+      const spark = document.createElement('canvas');
+      spark.classList.add('et0-sparkline');
+      spark.width = 100;
+      spark.height = 32;
+      spark.dataset.plantId = plant.id;
+      meta.appendChild(spark);
+    }
+    if (meta.childElementCount > 0) {
+      infoWrap.appendChild(meta);
+      const canvas = meta.querySelector('.et0-sparkline');
+      if (canvas) initEt0Sparkline(canvas);
     }
 
     const summary = document.createElement('div');

--- a/style.css
+++ b/style.css
@@ -1101,6 +1101,17 @@ button:focus {
   margin-bottom: calc(var(--spacing) * 1.5);
 }
 
+/* badges + sparkline container */
+.card-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: calc(var(--spacing) * 1.5);
+}
+.card-meta .tag-list {
+  margin-bottom: 0;
+}
+
 
 .tag {
   background-color: var(--color-accent);
@@ -1332,6 +1343,21 @@ button:focus {
   color: var(--color-surface);
 }
 #archived-link.hidden { display: none; }
+
+.et0-sparkline {
+  display: block;
+  width: 100px;
+  height: 32px;
+  background: rgba(0,0,0,0.02);
+  border-radius: 4px;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.05);
+  touch-action: pan-x;
+}
+
+#plant-grid.list-view .et0-sparkline,
+#plant-grid.text-view .et0-sparkline {
+  display: none;
+}
 
 
 


### PR DESCRIPTION
## Summary
- render ET₀ horizon chart in grid view plant cards
- style sparkline container

## Testing
- `php -v` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68635b84172483248d0b94a0fdec5ba6