### PR TITLE
Update ET₀ display to simple sparkline

### DIFF
--- a/script.js
+++ b/script.js
@@ -210,40 +210,30 @@ function initEt0Sparkline(canvas) {
     .then(data => {
       const et0 = data.map(d => parseFloat(d.et0_mm));
       canvas.title = 'ET\u2080 last 7 days';
+      // match canvas dimensions to the rendered size
+      canvas.width = canvas.clientWidth;
+      canvas.height = canvas.clientHeight;
       const ctx = canvas.getContext('2d');
-      const accentHex =
+      const accent =
         getComputedStyle(document.documentElement).getPropertyValue(
           '--color-accent'
         ) || '#228b22';
-      const color = hexToRgb(accentHex);
-
-      const bandSize = 2;
-      const maxVal = Math.max(...et0, bandSize);
-      const bands = Math.ceil(maxVal / bandSize);
-      const bandHeight = canvas.height / bands;
-      const step = canvas.width / et0.length;
 
       ctx.clearRect(0, 0, canvas.width, canvas.height);
+      const max = Math.max(...et0);
+      const min = Math.min(...et0);
+      const range = max - min || 1;
+      const step = canvas.width / (et0.length - 1);
 
-      for (let b = bands; b >= 1; b--) {
-        ctx.beginPath();
-        ctx.moveTo(0, canvas.height - bandHeight * b);
-        et0.forEach((v, i) => {
-          const capped = Math.min(
-            Math.max(v - bandSize * (b - 1), 0),
-            bandSize
-          );
-          const y =
-            canvas.height - bandHeight * b +
-            bandHeight - (capped / bandSize) * bandHeight;
-          ctx.lineTo(i * step, y);
-        });
-        ctx.lineTo(canvas.width, canvas.height - bandHeight * b);
-        ctx.closePath();
-        const alpha = 0.4 + (0.6 * b) / bands;
-        ctx.fillStyle = `rgba(${color.r},${color.g},${color.b},${alpha})`;
-        ctx.fill();
-      }
+      ctx.beginPath();
+      et0.forEach((v, i) => {
+        const x = i * step;
+        const y = canvas.height - ((v - min) / range) * canvas.height;
+        ctx.lineTo(x, y);
+      });
+      ctx.strokeStyle = accent.trim();
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
     })
     .catch(() => {});
 }
@@ -1529,8 +1519,6 @@ async function loadPlants() {
     if (viewMode === 'grid') {
       const spark = document.createElement('canvas');
       spark.classList.add('et0-sparkline');
-      spark.width = 100;
-      spark.height = 32;
       spark.dataset.plantId = plant.id;
       meta.appendChild(spark);
     }

--- a/style.css
+++ b/style.css
@@ -1106,6 +1106,7 @@ button:focus {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--spacing);
   margin-bottom: calc(var(--spacing) * 1.5);
 }
 .card-meta .tag-list {
@@ -1346,8 +1347,10 @@ button:focus {
 
 .et0-sparkline {
   display: block;
-  width: 100px;
-  height: 32px;
+  flex: 1;
+  width: 100%;
+  height: 1rem;
+  max-height: 1rem;
   background: rgba(0,0,0,0.02);
   border-radius: 4px;
   box-shadow: inset 0 1px 2px rgba(0,0,0,0.05);


### PR DESCRIPTION
## Summary
- simplify ET₀ chart rendering to a lightweight sparkline
- stretch sparkline next to tags and remove hardcoded size
- limit sparkline height in CSS

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68635fe21bf48324a9d7c2b5694f9841