### PR TITLE
Add offline support via service worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,7 @@ tasks (watering and fertilizing) at once. The card slides with your finger
 and smoothly snaps back if you don't pass the threshold.
 
 
+
+## Service Worker
+
+The app uses a simple service worker to cache core assets for offline access. During development you may need to update the cache when making changes. Bump the cache version in `service-worker.js` or run **Disable cache** in your browser's developer tools and reload to ensure the latest files are served.

--- a/index.html
+++ b/index.html
@@ -191,6 +191,13 @@
         <button id="next-week" class="bg-primary text-white rounded-md px-4 py-2"></button>
     </div>
     <div id="calendar" class="p-4"></div>
+    <script>
+      if ("serviceWorker" in navigator) {
+        window.addEventListener("load", () => {
+          navigator.serviceWorker.register("service-worker.js").catch(e => console.log("Service Worker registration failed:", e));
+        });
+      }
+    </script>
 
     <script>
       const script = document.createElement('script');

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,29 @@
+const CACHE_NAME = 'plant-tracker-v1';
+const ASSETS = [
+  '/',
+  'index.html',
+  'script.js',
+  'style.css',
+  'favicon.svg',
+  'screenshot.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- add a simple service worker that caches HTML, JS, CSS and image assets
- register the service worker on page load
- document how to update the service worker during development

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6863bbaeaca88324bf13f78e73d30e09