### PR TITLE
Add CSV export functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,7 @@ In list or text view you can swipe right on a plant card to complete all due
 tasks (watering and fertilizing) at once. The card slides with your finger
 and smoothly snaps back if you don't pass the threshold.
 
+You can also export your current plant list as JSON or CSV using the download
+buttons at the top of the page.
+
 

--- a/api/export_plants_csv.php
+++ b/api/export_plants_csv.php
@@ -1,0 +1,60 @@
+<?php
+$debug = getenv('DEBUG');
+if ($debug) {
+    ini_set('display_errors', 1);
+    error_reporting(E_ALL);
+}
+$dbConfig = getenv('DB_CONFIG');
+if ($dbConfig && file_exists($dbConfig)) {
+    include $dbConfig;
+} else {
+    include '../db.php';
+}
+
+if (!headers_sent()) {
+    header('Content-Type: text/csv');
+    header('Content-Disposition: attachment; filename="plants.csv"');
+}
+
+$archived = isset($_GET['archived']) && $_GET['archived'] == '1' ? 1 : 0;
+$stmt = $conn->prepare(
+    "SELECT id, name, species, plant_type, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount, archived FROM plants WHERE archived = ? ORDER BY id DESC"
+);
+if (!$stmt) {
+    @http_response_code(500);
+    if ($debug) {
+        echo 'Database error: ' . $conn->error;
+    }
+    return;
+}
+$stmt->bind_param('i', $archived);
+if (!$stmt->execute()) {
+    @http_response_code(500);
+    if ($debug) {
+        echo 'Database error: ' . $stmt->error;
+    }
+    return;
+}
+$res = $stmt->get_result();
+$out = fopen('php://output', 'w');
+
+fputcsv($out, [
+    'id',
+    'name',
+    'species',
+    'plant_type',
+    'watering_frequency',
+    'fertilizing_frequency',
+    'room',
+    'last_watered',
+    'last_fertilized',
+    'photo_url',
+    'water_amount',
+    'archived'
+]);
+while ($row = $res->fetch_assoc()) {
+    fputcsv($out, $row);
+}
+fclose($out);
+$stmt->close();
+?>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
         My Plant Tracker
         <button id="show-add-form" class="bg-primary text-white rounded-md px-4 py-2 ml-auto"></button>
         <button id="export-json" class="bg-primary text-white rounded-md px-4 py-2 ml-2"></button>
+        <button id="export-csv" class="bg-primary text-white rounded-md px-4 py-2 ml-2"></button>
         <button id="toggle-search" class="bg-primary text-white rounded-md px-4 py-2 ml-2">Search</button>
     </h1>
     <div id="summary" class="p-4 bg-card rounded-lg mb-4">

--- a/script.js
+++ b/script.js
@@ -1224,7 +1224,7 @@ function showFormStep(){
 
 async function exportPlantsJSON() {
   try {
-    const res = await fetch('api/get_plants.php');
+    const res = await fetch(`api/get_plants.php${showArchive ? '?archived=1' : ''}`);
     if (!res.ok) throw new Error();
     const data = await res.json();
     const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
@@ -1232,6 +1232,24 @@ async function exportPlantsJSON() {
     const link = document.createElement('a');
     link.href = url;
     link.download = 'plants.json';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  } catch (e) {
+    showToast('Export failed. Please try again.', true);
+  }
+}
+
+async function exportPlantsCSV() {
+  try {
+    const res = await fetch(`api/export_plants_csv.php${showArchive ? '?archived=1' : ''}`);
+    if (!res.ok) throw new Error();
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'plants.csv';
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
@@ -1770,6 +1788,7 @@ async function checkArchivedLink(plantsList) {
 function init(){
   const showBtn = document.getElementById('show-add-form');
   const exportBtn = document.getElementById('export-json');
+  const exportCsvBtn = document.getElementById('export-csv');
   const form = document.getElementById('plant-form');
   const cancelBtn = document.getElementById('cancel-edit');
   const undoBtn = document.getElementById('undo-btn');
@@ -1837,6 +1856,10 @@ function init(){
   if (exportBtn) {
     exportBtn.innerHTML = ICONS.download + '<span class="visually-hidden">Export JSON</span>';
     exportBtn.addEventListener('click', exportPlantsJSON);
+  }
+  if (exportCsvBtn) {
+    exportCsvBtn.innerHTML = ICONS.download + '<span class="visually-hidden">Export CSV</span>';
+    exportCsvBtn.addEventListener('click', exportPlantsCSV);
   }
   if (cancelBtn) {
     cancelBtn.innerHTML = ICONS.cancel + ' Cancel';


### PR DESCRIPTION
## Summary
- create `export_plants_csv.php` API endpoint
- add CSV export button in UI
- support CSV export in `script.js`
- document CSV export in README
- handle archived filter in export functions

## Testing
- `php -l api/export_plants_csv.php`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6863bbb7d3148324b92092d1bb5267ab