### PR TITLE
Remove unused RA constant

### DIFF
--- a/script.js
+++ b/script.js
@@ -31,7 +31,6 @@ const CM_PER_INCH = 2.54;
 const WEATHER_UPDATE_INTERVAL = 60 * 60 * 1000; // 1 hour
 
 // configuration values mirrored from config.php
-const RA = 20.0;
 const DEFAULT_KC = 0.8;
 // GBIF backbone usageKey for Plantae
 const PLANTAE_KEY = 6;


### PR DESCRIPTION
## Summary
- stop redefining `RA` in `script.js` and rely on `js/calc.js`

## Testing
- `npm test --silent`
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6863c18112a083249f9841ba6c12f19d