### PR TITLE
Consolidate export buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,8 +31,7 @@
     <h1 class="app-title text font-bold px-4 py-0">
         My Plant Tracker
         <button id="show-add-form" class="bg-primary text-white rounded-md px-4 py-2 ml-auto"></button>
-        <button id="export-json" class="bg-primary text-white rounded-md px-4 py-2 ml-2"></button>
-        <button id="export-csv" class="bg-primary text-white rounded-md px-4 py-2 ml-2"></button>
+        <button id="export-all" class="bg-primary text-white rounded-md px-4 py-2 ml-2"></button>
         <button id="toggle-search" class="bg-primary text-white rounded-md px-4 py-2 ml-2">Search</button>
     </h1>
     <div id="summary" class="p-4 bg-card rounded-lg mb-4">

--- a/script.js
+++ b/script.js
@@ -1206,6 +1206,11 @@ async function exportPlantsCSV() {
   }
 }
 
+async function exportPlantsBoth() {
+  await exportPlantsJSON();
+  await exportPlantsCSV();
+}
+
 // --- main render & filter loop ---
 async function loadPlants() {
   const res = await fetch(`api/get_plants.php${showArchive ? '?archived=1' : ''}`);
@@ -1734,8 +1739,7 @@ async function checkArchivedLink(plantsList) {
 // --- init ---
 function init(){
   const showBtn = document.getElementById('show-add-form');
-  const exportBtn = document.getElementById('export-json');
-  const exportCsvBtn = document.getElementById('export-csv');
+  const exportBtn = document.getElementById('export-all');
   const form = document.getElementById('plant-form');
   const cancelBtn = document.getElementById('cancel-edit');
   const undoBtn = document.getElementById('undo-btn');
@@ -1801,12 +1805,8 @@ function init(){
     showBtn.innerHTML = ICONS.plus + '<span class="visually-hidden">Add a Plant</span>';
   }
   if (exportBtn) {
-    exportBtn.innerHTML = ICONS.download + '<span class="visually-hidden">Export JSON</span>';
-    exportBtn.addEventListener('click', exportPlantsJSON);
-  }
-  if (exportCsvBtn) {
-    exportCsvBtn.innerHTML = ICONS.download + '<span class="visually-hidden">Export CSV</span>';
-    exportCsvBtn.addEventListener('click', exportPlantsCSV);
+    exportBtn.innerHTML = ICONS.download + '<span class="visually-hidden">Export</span>';
+    exportBtn.addEventListener('click', exportPlantsBoth);
   }
   if (cancelBtn) {
     cancelBtn.innerHTML = ICONS.cancel + ' Cancel';


### PR DESCRIPTION
## Summary
- replace separate JSON and CSV export buttons with a single "Export" button
- call both export functions from a new `exportPlantsBoth` helper

## Testing
- `npm test`
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6863c217b8408324aa393309cc04b569