### PR TITLE
Update test section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ php -S localhost:8000
 
 ## Running Tests
 
-PHPUnit tests are provided for the API endpoints. Run them from the project root:
+PHPUnit tests are provided for the API endpoints. Ensure PHP is available on the
+command line and that [PHPUnit is installed](https://phpunit.de/getting-started/phpunit-10.html).
+Run them from the project root:
 
 ```bash
 phpunit


### PR DESCRIPTION
## Summary
- note that PHP must be on the command line
- link to PHPUnit installation instructions in the README

## Testing
- `phpunit`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6863c641237483249308120595917aff