### PR TITLE
Improve README with quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,116 +1,60 @@
 # Plant Tracker
 
-Plant Tracker is a lightweight PHP application for managing your houseplants. It stores
-plant records in a MySQL database and provides a simple web interface to track
-watering and fertilizing. The project also includes small calculators for estimating
-water requirements using local weather data.
+Plant Tracker is a small web app for managing your houseplants. It runs on PHP with a MySQL database and uses vanilla JavaScript in the browser. Weather data from OpenWeather helps estimate how much to water each plant. Node.js is only needed for running the front-end tests.
 
-## Setup
+![Screenshot of Plant Tracker](screenshot.png)
 
-1. Clone the repository and install PHP and MySQL.
-2. Copy `config.example.php` to `config.php` and update the values:
+## Quick Start
 
-```php
-'openweather_key' => 'YOUR_API_KEY',
-'location'        => 'City,Country',
-'ra'              => 20.0,
-'kc'              => 0.8,
-'kc_map' => [
-    'succulent'  => 0.3,
-    'houseplant' => 0.8,
-    'vegetable'  => 1.0,
-    'flower'     => 0.9,
-    'cacti'      => 0.28,
-],
-'bed_map' => [
-    'vegetable' => [
-        'kcb' => [
-            'ini' => 0.3,
-            'mid' => 1.05,
-            'end' => 0.95,
-        ],
-        'kc_soil' => 1.1,
-    ],
-    'flower' => [
-        'kcb' => [
-            'ini' => 0.35,
-            'mid' => 1.1,
-            'end' => 1.0,
-        ],
-        'kc_soil' => 1.05,
-    ],
-],
-```
-
-   The OpenWeather API key and location are required for the water calculators.
-3. Configure your MySQL connection in `db.php` or using environment variables in
-   the testing stubs located under `tests/`.
-4. Run the database migrations:
-
-```bash
-php scripts/run_migrations.php
-```
-
-5. Start a local server from the project root:
-
-```bash
-php -S localhost:8000
-```
-
-   Then open `http://localhost:8000/index.html` in your browser.
-
-   **Note:** Opening `index.html` directly as a file won't work because the
-   JavaScript needs the PHP API endpoints. Always access the app through the
-   local server above.
+1. Install PHP, MySQL and Node.js.
+2. Clone the repository.
+3. Copy `config.example.php` to `config.php` and fill in your OpenWeather key and location.
+4. Copy `db.example.php` to `db.php` and enter your database credentials.
+5. Create a MySQL database and run the migrations:
+   ```bash
+   php scripts/run_migrations.php
+   ```
+6. Install the Node dependencies:
+   ```bash
+   npm install
+   ```
+7. Start the development server and open the app:
+   ```bash
+   php -S localhost:8000
+   ```
+   Visit [http://localhost:8000/index.html](http://localhost:8000/index.html). **index.html must be loaded through this PHP server or the API calls will fail.**
 
 ## Running Tests
 
-PHPUnit tests are provided for the API endpoints. Run them from the project root:
+Two small test suites come with the project. Run the PHP API tests with:
 
 ```bash
 phpunit
 ```
 
-JavaScript unit tests are written with Jest and live in the `__tests__/`
-directory. They exercise the front‑end utility functions and DOM helpers.
-Install the Node dependencies and run them with:
+The front-end utilities are tested with Jest. Run those with:
 
 ```bash
-npm install
 npm test
 ```
 
-Together the suites validate basic input handling for the API as well as
-core front‑end behaviour.
-
 ## Calculators
 
-Two small utilities help estimate watering needs:
+Two utilities estimate watering needs:
 
-- `calculator.php` &mdash; calculates daily water for a single pot using weather data.
-- `bed_calculator.php` &mdash; computes irrigation for an entire garden bed.
+- `calculator.php` – calculates daily water for a single pot using weather data.
+- `bed_calculator.php` – computes irrigation for a whole garden bed.
 
-Both rely on the coefficients defined in `config.php`.
-
-Weather data retrieved from OpenWeather is cached for one hour to limit API
-requests and speed up page loads. The calculators automatically use the cached
-response if available.
+Both rely on the coefficients defined in `config.php` and use cached OpenWeather responses.
 
 ## Basic Usage
 
-Use the main interface at `index.html` to add plants, mark them as watered or
-fertilized, and upload photos. The API endpoints under `api/` are used by the
-front‑end JavaScript (`script.js`) to interact with the database.
+Use the main interface at `index.html` to add plants, mark them as watered or fertilized and upload photos. The API endpoints under `api/` are called by `script.js`.
 
-In list or text view you can swipe right on a plant card to complete all due
-tasks (watering and fertilizing) at once. The card slides with your finger
-and smoothly snaps back if you don't pass the threshold.
+In list or text view you can swipe right on a plant card to complete all due tasks at once. Cards slide with your finger and snap back if you don't pass the threshold.
 
-You can also export your current plant list as JSON or CSV using the download
-buttons at the top of the page.
-
-
+You can also export your current plant list as JSON or CSV using the download buttons at the top of the page.
 
 ## Service Worker
 
-The app uses a simple service worker to cache core assets for offline access. During development you may need to update the cache when making changes. Bump the cache version in `service-worker.js` or run **Disable cache** in your browser's developer tools and reload to ensure the latest files are served.
+The app uses a simple service worker to cache core assets for offline access. During development you may need to update the cache when making changes. Bump the cache version in `service-worker.js` or clear your browser cache to ensure the latest files are served.


### PR DESCRIPTION
## Summary
- simplify project introduction and mention technologies
- add a concise Quick Start guide
- note that index.html must be opened via the PHP server
- document how to run both PHP and JS tests
- embed screenshot

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6863c63b53108324a24fe6a35e58a58a