### PR TITLE
Update README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Plant Tracker is a small PHP web app that helps you keep your houseplants health
 ```
 
    The OpenWeather API key and location are required for the water calculators.
+   `script.js` also defines a `WEATHER_API_KEY` constant. Unless you implement the automatic injection described above, set this constant to your own key as well. Leaving the placeholder in place will cause 401 errors from OpenWeather.
 3. Copy `db.example.php` to `db.php` and add your MySQL credentials.
 4. Run the database migrations:
 


### PR DESCRIPTION
## Summary
- clarify that `script.js` also requires a `WEATHER_API_KEY` value

## Testing
- `phpunit`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863cefb18c8832493112880de79e621