### PR TITLE
Add endpoint to serve OpenWeather API key

### DIFF
--- a/api/weather_key.php
+++ b/api/weather_key.php
@@ -1,0 +1,20 @@
+<?php
+if (!headers_sent()) {
+    header('Content-Type: application/json');
+}
+$configFile = __DIR__ . '/../config.php';
+if (!file_exists($configFile)) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Config file missing']);
+    return;
+}
+$config = include $configFile;
+$key = $config['openweather_key'] ?? null;
+if (!$key) {
+    http_response_code(500);
+    echo json_encode(['error' => 'API key not set']);
+    return;
+}
+http_response_code(200);
+echo json_encode(['key' => $key]);
+?>


### PR DESCRIPTION
## Summary
- create `weather_key.php` endpoint to expose key from config
- fetch key on startup in `script.js`
- update `fetchWeather()` to handle async key retrieval

## Testing
- `npm test`
- `phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6863cef3bb8c8324a985847772ddb514