### PR TITLE
Improve toast and undo banner accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,12 +176,12 @@
     <div id="rainfall-info" class="p-4 bg-card rounded-lg mb-4 hidden"></div>
 
     <!-- Undo delete snackbar -->
-    <div id="undo-banner" class="mb-4" role="alert">
+    <div id="undo-banner" class="mb-4" role="status" aria-live="polite" aria-hidden="true">
         <span id="undo-message">Plant deleted.</span>
         <button id="undo-btn">Undo</button>
     </div>
 
-    <div id="toast" class="toast"></div>
+    <div id="toast" class="toast" role="status" aria-live="polite" aria-hidden="true"></div>
 
     <div id="plant-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 p-4"></div>
     <button id="archived-link" type="button" class="text-sm hidden"></button>

--- a/js/dom.js
+++ b/js/dom.js
@@ -4,9 +4,11 @@ export function showToast(msg, isError = false) {
   toast.textContent = msg;
   toast.classList.toggle('error', isError);
   toast.classList.add('show');
+  toast.setAttribute('aria-hidden', 'false');
   clearTimeout(toast.hideTimeout);
   toast.hideTimeout = setTimeout(() => {
     toast.classList.remove('show');
+    toast.setAttribute('aria-hidden', 'true');
   }, 3000);
 }
 

--- a/script.js
+++ b/script.js
@@ -130,10 +130,12 @@ function showUndoActionBanner(plant, actions, prevWater, prevFert) {
   }
   banner.classList.add('success');
   banner.classList.add('show');
+  banner.setAttribute('aria-hidden', 'false');
   clearTimeout(actionTimer);
   actionTimer = setTimeout(() => {
     banner.classList.remove('show');
     banner.classList.remove('success');
+    banner.setAttribute('aria-hidden', 'true');
     lastCompletedAction = null;
   }, 5000);
 }
@@ -947,6 +949,7 @@ function showUndoBanner(plant) {
   if (msg) msg.textContent = 'Plant deleted.';
   banner.classList.remove('success');
   banner.classList.add('show');
+  banner.setAttribute('aria-hidden', 'false');
   clearTimeout(deleteTimer);
   deleteTimer = setTimeout(async () => {
     await fetch('api/delete_plant.php', {
@@ -955,6 +958,7 @@ function showUndoBanner(plant) {
       body: `id=${plant.id}`
     });
     banner.classList.remove('show');
+    banner.setAttribute('aria-hidden', 'true');
     lastDeletedPlant = null;
     loadPlants();
   }, 5000);
@@ -1918,6 +1922,7 @@ async function init(){
   document.getElementById('undo-btn').addEventListener('click', async () => {
     const banner = document.getElementById('undo-banner');
     banner.classList.remove('show');
+    banner.setAttribute('aria-hidden', 'true');
     if (lastDeletedPlant) {
       clearTimeout(deleteTimer);
       lastDeletedPlant = null;

--- a/style.css
+++ b/style.css
@@ -529,13 +529,13 @@ button:focus {
   font-size: var(--font-size-lg);
   font-weight: 600;
   opacity: 0;
+  visibility: hidden;
   pointer-events: none;
   transition: opacity 0.3s ease;
-  display: none;
 }
 
 .toast.show {
-  display: block;
+  visibility: visible;
   opacity: 1;
 }
 


### PR DESCRIPTION
## Summary
- mark toast and undo banner as status regions for screen readers
- keep toast element visible but hidden using CSS
- ensure toast and undo banner toggle `aria-hidden` via JS

## Testing
- `phpunit`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6863d5343ef883248ec24afd0720c9ab