### PR TITLE
Add analytics logging and page

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Use the main interface at `index.html` to add plants, mark them as watered or fe
 In list or text view you can swipe right on a plant card to complete all due tasks (watering and fertilizing) at once. The card slides with your finger and smoothly snaps back if you don't pass the threshold.
 
 You can also export your current plant list as JSON or CSV using the download buttons at the top of the page.
+The new **Analytics** link opens a page with charts of historical ET₀ and water use.
 
 ## Service Worker
 A small service worker caches the key pages and scripts so the app still opens when you're offline. During development you may need to disable the cache or bump the version in `service-worker.js` to pick up changes.

--- a/analytics.html
+++ b/analytics.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Plant Analytics</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+  <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body class="bg-bg text-text min-h-screen p-4">
+  <h1 class="text-2xl font-bold mb-4">Plant Analytics
+    <a href="index.html" class="ml-4 text-sm text-primary underline">Back</a>
+  </h1>
+  <div class="flex flex-wrap gap-2 mb-4">
+    <select id="plantSelect" class="border p-2"></select>
+    <input type="date" id="startDate" class="border p-2">
+    <input type="date" id="endDate" class="border p-2">
+    <button id="refresh" class="bg-primary text-white rounded-md px-3 py-2">Show</button>
+  </div>
+  <canvas id="et0Chart" width="600" height="300" class="mb-4 bg-white"></canvas>
+  <div id="heatmap" class="mb-4"></div>
+  <table id="dataTable" class="min-w-full border"></table>
+  <script type="module" src="analytics.js"></script>
+</body>
+</html>

--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,104 @@
+const ctx = document.getElementById('et0Chart').getContext('2d');
+let et0Chart;
+
+function drawChart(data) {
+  const labels = data.map(r => r.date);
+  const et0 = data.map(r => parseFloat(r.et0_mm));
+  const water = data.map(r => parseFloat(r.water_ml));
+  if (et0Chart) et0Chart.destroy();
+  et0Chart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels,
+      datasets: [
+        {
+          label: 'ET₀ (mm)',
+          data: et0,
+          yAxisID: 'y1',
+          borderColor: '#4CAF50',
+          fill: false,
+        },
+        {
+          label: 'Water (mL)',
+          data: water,
+          yAxisID: 'y2',
+          borderColor: '#2196F3',
+          fill: true,
+          backgroundColor: 'rgba(33,150,243,0.2)'
+        }
+      ]
+    },
+    options: {
+      scales: {
+        y1: { type: 'linear', position: 'left' },
+        y2: { type: 'linear', position: 'right' }
+      },
+      interaction: { mode: 'index', intersect: false },
+      plugins: { legend: { position: 'bottom' } }
+    }
+  });
+}
+
+function drawHeatmap(data) {
+  const container = document.getElementById('heatmap');
+  container.innerHTML = '';
+  if (data.length === 0) return;
+  const maxEt0 = Math.max(...data.map(r => parseFloat(r.et0_mm)));
+  data.forEach((row, idx) => {
+    const cell = document.createElement('div');
+    const pct = parseFloat(row.et0_mm) / maxEt0;
+    const hue = 120 - (pct * 120);
+    cell.style.cssText = `width:12px;height:12px;margin:1px;background:hsl(${hue},60%,50%);display:inline-block;`;
+    container.appendChild(cell);
+    if ((idx + 1) % 7 === 0) container.appendChild(document.createElement('br'));
+  });
+}
+
+function fillTable(data) {
+  const tbl = document.getElementById('dataTable');
+  tbl.innerHTML = '';
+  if (data.length === 0) return;
+  const head = document.createElement('tr');
+  head.innerHTML = '<th>Date</th><th>ET₀ (mm)</th><th>Water (mL)</th>';
+  tbl.appendChild(head);
+  data.forEach(r => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${r.date}</td><td>${r.et0_mm}</td><td>${r.water_ml}</td>`;
+    tbl.appendChild(tr);
+  });
+}
+
+async function loadTimeseries() {
+  const plantId = document.getElementById('plantSelect').value;
+  if (!plantId) return;
+  const start = document.getElementById('startDate').value;
+  const end = document.getElementById('endDate').value;
+  let days = 30;
+  if (start && end) {
+    const s = new Date(start);
+    const e = new Date(end);
+    days = Math.max(1, Math.ceil((e - s) / 86400000) + 1);
+  }
+  const res = await fetch(`api/get_et0_timeseries.php?plant_id=${plantId}&days=${days}`);
+  if (!res.ok) return;
+  const data = await res.json();
+  drawChart(data);
+  drawHeatmap(data);
+  fillTable(data);
+}
+
+async function loadPlants() {
+  const res = await fetch('api/get_plants.php');
+  if (!res.ok) return;
+  const plants = await res.json();
+  const sel = document.getElementById('plantSelect');
+  plants.forEach(p => {
+    const opt = document.createElement('option');
+    opt.value = p.id;
+    opt.textContent = p.name;
+    sel.appendChild(opt);
+  });
+}
+
+document.getElementById('refresh').addEventListener('click', loadTimeseries);
+loadPlants();

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
         <button id="show-add-form" class="bg-primary text-white rounded-md px-4 py-2 ml-auto"></button>
         <button id="export-all" class="bg-primary text-white rounded-md px-4 py-2 ml-2"></button>
         <button id="toggle-search" class="bg-primary text-white rounded-md px-4 py-2 ml-2">Search</button>
+        <a href="analytics.html" class="bg-primary text-white rounded-md px-4 py-2 ml-2">Analytics</a>
     </h1>
     <div id="summary" class="p-4 bg-card rounded-lg mb-4">
         <!-- counts will go here -->

--- a/migrations/005_create_et0_log.sql
+++ b/migrations/005_create_et0_log.sql
@@ -1,0 +1,9 @@
+-- Create table to log daily ET0 and derived water volume
+CREATE TABLE IF NOT EXISTS et0_log (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    plant_id INT NOT NULL,
+    date DATE NOT NULL,
+    et0_mm DECIMAL(5,2) NOT NULL,
+    water_ml DECIMAL(7,1) NOT NULL,
+    FOREIGN KEY (plant_id) REFERENCES plants(id)
+);

--- a/script.js
+++ b/script.js
@@ -415,6 +415,14 @@ function updateWaterAmount() {
   const oz = waterMl / ML_PER_US_FL_OUNCE;
   waterAmtInput.value = oz.toFixed(1);
   waterAmtInput.dispatchEvent(new Event('input', { bubbles: true }));
+  if (editingPlantId) {
+    const body = new URLSearchParams({
+      plant_id: editingPlantId,
+      et0_mm: et0.toFixed(2),
+      water_ml: waterMl.toFixed(1)
+    });
+    fetch('api/log_et0.php', { method: 'POST', body }).catch(() => {});
+  }
 }
 
 function updateWateringFrequency() {


### PR DESCRIPTION
## Summary
- create `et0_log` table via new migration
- log ET0 values from the client using a new `log_et0.php`
- serve ET0 time series from database
- add Analytics page with charts and heatmap
- link Analytics from the main UI
- document Analytics page

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6863de5178488324b6d25e16003f47ed