### PR TITLE
Fix overflow menu visibility for plant cards

### DIFF
--- a/script.js
+++ b/script.js
@@ -1421,7 +1421,10 @@ async function loadPlants() {
       img.sizes = '(max-width: 640px) 100vw, 400px';
     }
     img.classList.add('plant-photo');
-    card.appendChild(img);
+    const photoWrap = document.createElement('div');
+    photoWrap.classList.add('photo-wrap');
+    photoWrap.appendChild(img);
+    card.appendChild(photoWrap);
 
     const infoWrap = document.createElement('div');
     infoWrap.classList.add('plant-info');

--- a/style.css
+++ b/style.css
@@ -906,12 +906,12 @@ button:focus {
   padding: calc(var(--spacing) * 2);
   display: flex;
   flex-direction: column;
-  overflow: hidden; /* clip photo when it extends to edges */
   position: relative; /* allow urgency tag overlay */
   box-shadow: 0 1px 2px rgba(0,0,0,0.05);
   transition: box-shadow 0.2s, transform 0.2s;
   touch-action: pan-y; /* allow horizontal swipe gestures */
   user-select: none;
+  overflow: visible; /* allow overflow menu to appear */
 }
 
 .plant-card:hover {
@@ -1055,13 +1055,18 @@ button:focus {
   border: 1px solid var(--color-plant);
 }
 
+.photo-wrap {
+  overflow: hidden;
+  border-radius: 12px;
+  margin-bottom: calc(var(--spacing) * 1.5);
+}
+
 .plant-card .plant-photo {
   width: 100%;
   height: auto;
   aspect-ratio: 1/1;
   object-fit: cover;
   display: block;
-  margin-bottom: calc(var(--spacing) * 1.5);
   border-radius: 12px;
 }
 


### PR DESCRIPTION
## Summary
- let plant cards allow overflow so menu buttons are visible
- keep photos clipped with new `.photo-wrap` wrapper
- update plant card creation to insert the new wrapper

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68640905553883248fcd72b6257d35e5