### PR TITLE
Add plant name autocomplete via OpenFarm

### DIFF
--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -51,6 +51,8 @@ $water_amount = isset($_POST['water_amount']) ? floatval($_POST['water_amount'])
 $last_watered = $_POST['last_watered'] ?? null;
 $last_fertilized = $_POST['last_fertilized'] ?? null;
 $photo_url = trim($_POST['photo_url'] ?? '');
+$scientificName = $_POST['scientific_name'] ?? '';
+$thumbnailUrl   = $_POST['thumbnail_url']   ?? '';
 
 // further validation
 $errors = [];
@@ -110,8 +112,10 @@ $stmt = $conn->prepare(
         last_watered,
         last_fertilized,
         photo_url,
-        water_amount
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        water_amount,
+        scientific_name,
+        thumbnail_url
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 );
 if (!$stmt) {
     @http_response_code(500);
@@ -126,7 +130,7 @@ if (!$stmt) {
     return;
 }
 $stmt->bind_param(
-    "ssssiisssd",
+    "ssssiisssdss",
     $name,
     $species,
     $plant_type,
@@ -136,7 +140,9 @@ $stmt->bind_param(
     $last_watered,
     $last_fertilized,
     $photo_url,
-    $water_amount
+    $water_amount,
+    $scientificName,
+    $thumbnailUrl
 );
 
 if (!$stmt->execute()) {

--- a/api/export_plants_csv.php
+++ b/api/export_plants_csv.php
@@ -18,7 +18,7 @@ if (!headers_sent()) {
 
 $archived = isset($_GET['archived']) && $_GET['archived'] == '1' ? 1 : 0;
 $stmt = $conn->prepare(
-    "SELECT id, name, species, plant_type, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount, archived FROM plants WHERE archived = ? ORDER BY id DESC"
+    "SELECT id, name, species, plant_type, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount, scientific_name, thumbnail_url, archived FROM plants WHERE archived = ? ORDER BY id DESC"
 );
 if (!$stmt) {
     @http_response_code(500);
@@ -50,6 +50,8 @@ fputcsv($out, [
     'last_fertilized',
     'photo_url',
     'water_amount',
+    'scientific_name',
+    'thumbnail_url',
     'archived'
 ]);
 while ($row = $res->fetch_assoc()) {

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -18,7 +18,7 @@ if (!headers_sent()) {
 $plants = [];
 $archived = isset($_GET['archived']) && $_GET['archived'] == '1' ? 1 : 0;
 $stmt = $conn->prepare(
-    "SELECT id, name, species, plant_type, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount, archived
+    "SELECT id, name, species, plant_type, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount, scientific_name, thumbnail_url, archived
     FROM plants WHERE archived = ? ORDER BY id DESC"
 );
 if (!$stmt) {

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -33,6 +33,8 @@ $water_amount            = isset($_POST['water_amount']) ? floatval($_POST['wate
 $last_watered            = $_POST['last_watered'] ?? null;
 $last_fertilized         = $_POST['last_fertilized'] ?? null;
 $photo_url               = trim($_POST['photo_url'] ?? '');
+$scientificName          = $_POST['scientific_name'] ?? '';
+$thumbnailUrl            = $_POST['thumbnail_url'] ?? '';
 
 $errors = [];
 $namePattern = "/^[\p{L}0-9\s'-]{1,100}$/u";
@@ -136,11 +138,13 @@ $stmt = $conn->prepare("
         last_watered       = ?,
         last_fertilized    = ?,
         photo_url          = ?,
-        water_amount       = ?
+        water_amount       = ?,
+        scientific_name    = ?,
+        thumbnail_url      = ?
     WHERE id = ?
 ");
 $stmt->bind_param(
-    'ssssiisssdi',
+    'ssssiisssdssi',
     $name,
     $species,
     $plant_type,
@@ -151,6 +155,8 @@ $stmt->bind_param(
     $last_fertilized,
     $photo_url,
     $water_amount,
+    $scientificName,
+    $thumbnailUrl,
     $id
 );
 

--- a/index.html
+++ b/index.html
@@ -55,9 +55,14 @@
         <fieldset class="form-section flex flex-col gap-4">
             <legend class="font-semibold">Plant Basics</legend>
             <div>
-                <label for="name" class="block mb-1">Plant Name <span class="required-star" aria-hidden="true">*</span></label>
-                <input type="text" name="name" id="name" list="common-list" placeholder="Plant Name" class="w-full border rounded-md p-2" required />
-                <datalist id="common-list"></datalist>
+                <label for="plant-search" class="block mb-1">Plant Name <span class="required-star" aria-hidden="true">*</span></label>
+                <input type="text" name="name" id="plant-search" autocomplete="off" placeholder="Plant Name" class="w-full border rounded-md p-2" required />
+                <ul id="suggestions" class="autocomplete-list"></ul>
+
+                <!-- hidden, populated by JS -->
+                <input type="hidden" id="scientific-name" name="scientific_name" />
+                <input type="hidden" id="thumbnail-url" name="thumbnail_url" />
+                <img id="thumb-preview" src="" alt="Plant thumbnail" style="display:none; width:50px; margin-top:0.5rem;" />
                 <div class="error" id="name-error"></div>
             </div>
             <div>

--- a/migrations/006_add_scientific_thumbnail.sql
+++ b/migrations/006_add_scientific_thumbnail.sql
@@ -1,0 +1,4 @@
+-- Add scientific_name and thumbnail_url columns to plants
+ALTER TABLE plants
+  ADD COLUMN scientific_name VARCHAR(255) NULL,
+  ADD COLUMN thumbnail_url   VARCHAR(512) NULL;

--- a/script.js
+++ b/script.js
@@ -1783,7 +1783,7 @@ async function init(){
   const overrideCheck = document.getElementById('override_water');
   const waterGroup = document.getElementById('water-amount-group');
   const roomInput = document.getElementById('room');
-  const nameInput = document.getElementById('name');
+  const nameInput = document.getElementById('plant-search');
   const speciesInput = document.getElementById('species');
   const potHelp = document.getElementById('pot_diameter_help');
   const speciesList = document.getElementById('species-list');
@@ -2158,3 +2158,47 @@ if (document.readyState === 'loading') {
 }
 
 export { loadCalendar };
+
+// === Plant Name Autocomplete (OpenFarm) ===
+;(function(){
+  const input     = document.getElementById('plant-search');
+  const list      = document.getElementById('suggestions');
+  const sciField  = document.getElementById('scientific-name');
+  const thumbField= document.getElementById('thumbnail-url');
+  const preview   = document.getElementById('thumb-preview');
+  let timer;
+
+  if (!input) return;
+
+  input.addEventListener('input', e => {
+    clearTimeout(timer);
+    const q = e.target.value.trim();
+    if (!q) return list.innerHTML = '';
+    timer = setTimeout(() => {
+      fetch(`https://openfarm.cc/api/v1/crops/?filter=${encodeURIComponent(q)}`)
+        .then(r => r.json())
+        .then(json => {
+          list.innerHTML = '';
+          (json.data || []).slice(0, 8).forEach(({attributes: a}) => {
+            const item = document.createElement('li');
+            item.textContent = a.name + (a.binomial_name ? ` (${a.binomial_name})` : '');
+            item.onclick = () => {
+              input.value      = a.name;
+              sciField.value   = a.binomial_name || '';
+              thumbField.value = a.main_image_path || '';
+              if (a.main_image_path) {
+                preview.src = a.main_image_path;
+                preview.style.display = 'block';
+              }
+              list.innerHTML = '';
+            };
+            list.appendChild(item);
+          });
+        });
+    }, 300);
+  });
+
+  document.addEventListener('click', e => {
+    if (e.target !== input) list.innerHTML = '';
+  });
+})();

--- a/style.css
+++ b/style.css
@@ -1338,6 +1338,30 @@ button:focus {
 }
 #archived-link.hidden { display: none; }
 
+.autocomplete-list {
+  position: absolute;
+  background: #fff;
+  border: 1px solid #ccc;
+  width: calc(100% - 2px);
+  max-height: 200px;
+  overflow-y: auto;
+  margin-top: 0;
+  padding: 0;
+  list-style: none;
+  z-index: 10;
+}
+.autocomplete-list li {
+  padding: 0.5rem;
+  cursor: pointer;
+}
+.autocomplete-list li:hover {
+  background: #f0f0f0;
+}
+#thumb-preview {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- add OpenFarm-powered autocomplete to the plant name field
- style suggestion dropdown
- support new scientific name and thumbnail fields in PHP APIs
- include new columns in CSV export and migrations

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68647085ad008324911d40c0afa9170b