### PR TITLE
Add plant name suggestions from OpenFarm

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,8 +56,13 @@
             <legend class="font-semibold">Plant Basics</legend>
             <div>
                 <label for="name" class="block mb-1">Plant Name <span class="required-star" aria-hidden="true">*</span></label>
-                <input type="text" name="name" id="name" list="common-list" placeholder="Plant Name" class="w-full border rounded-md p-2" required />
-                <datalist id="common-list"></datalist>
+                <div class="relative">
+                    <input type="text" name="name" id="name" placeholder="Plant Name" class="w-full border rounded-md p-2" autocomplete="off" required />
+                    <ul id="name-suggestions" class="suggestions"></ul>
+                </div>
+                <input type="hidden" name="sci_name" id="sci_name">
+                <input type="hidden" name="image_url" id="image_url">
+                <img id="name-preview" class="mt-2 w-16 h-16 hidden" alt="preview">
                 <div class="error" id="name-error"></div>
             </div>
             <div>

--- a/style.css
+++ b/style.css
@@ -1338,6 +1338,30 @@ button:focus {
 }
 #archived-link.hidden { display: none; }
 
+.suggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  max-height: 200px;
+  overflow-y: auto;
+  z-index: 50;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.suggestions li {
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+}
+
+.suggestions li:hover {
+  background: var(--color-highlight);
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- show a suggestion dropdown for plant names
- style suggestion dropdown
- query OpenFarm for plant name suggestions and fill hidden fields with details

## Testing
- `npm test`
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686476aee2e88324a69a296b4fc2251b