### PR TITLE
Add OpenFarm metadata columns

### DIFF
--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -51,6 +51,8 @@ $water_amount = isset($_POST['water_amount']) ? floatval($_POST['water_amount'])
 $last_watered = $_POST['last_watered'] ?? null;
 $last_fertilized = $_POST['last_fertilized'] ?? null;
 $photo_url = trim($_POST['photo_url'] ?? '');
+$scientific_name = trim($_POST['scientific_name'] ?? '');
+$thumbnail_url  = trim($_POST['thumbnail_url'] ?? '');
 
 // further validation
 $errors = [];
@@ -110,8 +112,10 @@ $stmt = $conn->prepare(
         last_watered,
         last_fertilized,
         photo_url,
-        water_amount
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+        water_amount,
+        scientific_name,
+        thumbnail_url
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
 );
 if (!$stmt) {
     @http_response_code(500);
@@ -126,7 +130,7 @@ if (!$stmt) {
     return;
 }
 $stmt->bind_param(
-    "ssssiisssd",
+    "ssssiisssdss",
     $name,
     $species,
     $plant_type,
@@ -136,7 +140,9 @@ $stmt->bind_param(
     $last_watered,
     $last_fertilized,
     $photo_url,
-    $water_amount
+    $water_amount,
+    $scientific_name,
+    $thumbnail_url
 );
 
 if (!$stmt->execute()) {

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -18,7 +18,7 @@ if (!headers_sent()) {
 $plants = [];
 $archived = isset($_GET['archived']) && $_GET['archived'] == '1' ? 1 : 0;
 $stmt = $conn->prepare(
-    "SELECT id, name, species, plant_type, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount, archived
+    "SELECT id, name, species, plant_type, watering_frequency, fertilizing_frequency, room, last_watered, last_fertilized, photo_url, water_amount, scientific_name, thumbnail_url, archived
     FROM plants WHERE archived = ? ORDER BY id DESC"
 );
 if (!$stmt) {

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -33,6 +33,8 @@ $water_amount            = isset($_POST['water_amount']) ? floatval($_POST['wate
 $last_watered            = $_POST['last_watered'] ?? null;
 $last_fertilized         = $_POST['last_fertilized'] ?? null;
 $photo_url               = trim($_POST['photo_url'] ?? '');
+$scientific_name         = trim($_POST['scientific_name'] ?? '');
+$thumbnail_url           = trim($_POST['thumbnail_url'] ?? '');
 
 $errors = [];
 $namePattern = "/^[\p{L}0-9\s'-]{1,100}$/u";
@@ -136,11 +138,13 @@ $stmt = $conn->prepare("
         last_watered       = ?,
         last_fertilized    = ?,
         photo_url          = ?,
-        water_amount       = ?
+        water_amount       = ?,
+        scientific_name    = ?,
+        thumbnail_url      = ?
     WHERE id = ?
 ");
 $stmt->bind_param(
-    'ssssiisssdi',
+    'ssssiisssdssi',
     $name,
     $species,
     $plant_type,
@@ -151,6 +155,8 @@ $stmt->bind_param(
     $last_fertilized,
     $photo_url,
     $water_amount,
+    $scientific_name,
+    $thumbnail_url,
     $id
 );
 

--- a/migrations/006_add_openfarm_columns.sql
+++ b/migrations/006_add_openfarm_columns.sql
@@ -1,0 +1,4 @@
+-- Add columns for OpenFarm metadata
+ALTER TABLE plants
+    ADD COLUMN scientific_name VARCHAR(100) NULL,
+    ADD COLUMN thumbnail_url VARCHAR(255) NULL;


### PR DESCRIPTION
## Summary
- add `scientific_name` and `thumbnail_url` columns via migration
- support new fields in `add_plant` and `update_plant`
- return OpenFarm metadata in `get_plants`

## Testing
- `phpunit`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686476b5c5b88324ac1583d903b810b1