### PR TITLE
Add per-plant analytics links

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1,5 +1,7 @@
 const ctx = document.getElementById('et0Chart').getContext('2d');
 let et0Chart;
+const urlParams = new URLSearchParams(window.location.search);
+const initialPlantId = urlParams.get('plant_id');
 
 function drawChart(data) {
   const labels = data.map(r => r.date);
@@ -98,6 +100,10 @@ async function loadPlants() {
     opt.textContent = p.name;
     sel.appendChild(opt);
   });
+  if (initialPlantId) {
+    sel.value = initialPlantId;
+    await loadTimeseries();
+  }
 }
 
 document.getElementById('refresh').addEventListener('click', loadTimeseries);

--- a/index.html
+++ b/index.html
@@ -35,7 +35,6 @@
         <button id="show-add-form" class="bg-primary text-white rounded-md px-4 py-2 ml-auto"></button>
         <button id="export-all" class="bg-primary text-white rounded-md px-4 py-2 ml-2"></button>
         <button id="toggle-search" class="bg-primary text-white rounded-md px-4 py-2 ml-2">Search</button>
-        <a href="analytics.html" class="bg-primary text-white rounded-md px-4 py-2 ml-2">Analytics</a>
     </h1>
     <div id="summary" class="p-4 bg-card rounded-lg mb-4">
         <!-- counts will go here -->

--- a/script.js
+++ b/script.js
@@ -473,7 +473,8 @@ const ICONS = {
   grid: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>',
   text: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg>',
   menu: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="5" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="19" r="2"/></svg>',
-  archive: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5" rx="2" ry="2"/><line x1="10" y1="12" x2="14" y2="12"/></svg>'
+  archive: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="21 8 21 21 3 21 3 8"/><rect x="1" y="3" width="22" height="5" rx="2" ry="2"/><line x1="10" y1="12" x2="14" y2="12"/></svg>',
+  analytics: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>'
 };
 
 
@@ -1578,6 +1579,13 @@ async function loadPlants() {
       };
       actionsDiv.appendChild(snooze);
     }
+
+    const analyticsLink = document.createElement('a');
+    analyticsLink.classList.add('action-btn');
+    analyticsLink.innerHTML = ICONS.analytics + '<span class="visually-hidden">Analytics</span>';
+    analyticsLink.title = 'Analytics';
+    analyticsLink.href = `analytics.html?plant_id=${plant.id}`;
+    actionsDiv.appendChild(analyticsLink);
 
     const fileInput = document.createElement('input');
     fileInput.type = 'file';


### PR DESCRIPTION
## Summary
- remove global Analytics link
- add analytics SVG icon and link in each plant card
- allow analytics page to select plant via query param

## Testing
- `npm test`
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_68647694127c8324bbd0f70fed612746