### PR TITLE
Fix duplicate column error in migration

### DIFF
--- a/migrations/006_add_openfarm_columns.sql
+++ b/migrations/006_add_openfarm_columns.sql
@@ -1,4 +1,4 @@
 -- Add columns for OpenFarm metadata
 ALTER TABLE plants
-    ADD COLUMN scientific_name VARCHAR(100) NULL,
-    ADD COLUMN thumbnail_url VARCHAR(255) NULL;
+    ADD COLUMN IF NOT EXISTS scientific_name VARCHAR(100) NULL,
+    ADD COLUMN IF NOT EXISTS thumbnail_url VARCHAR(255) NULL;


### PR DESCRIPTION
## Summary
- add `IF NOT EXISTS` clauses to `006_add_openfarm_columns.sql` so the migration can run even if the columns already exist

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68647a20956883249a5026fe39b37c25