### PR TITLE
Improve styling of analytics page

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -31,20 +31,28 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body class="bg-bg text-text min-h-screen">
-  <h1 class="app-title text font-bold px-4 py-0">
-    Plant Analytics
-    <a href="index.html" class="bg-primary text-white rounded-md px-4 py-2 ml-auto">Home</a>
-  </h1>
-  <div class="p-4 flex flex-wrap gap-2 mb-4 bg-card rounded-lg">
-    <select id="plantSelect" class="border p-2"></select>
-    <input type="date" id="startDate" class="border p-2">
-    <input type="date" id="endDate" class="border p-2">
-    <button id="refresh" class="bg-primary text-white rounded-md px-3 py-2">Show</button>
-  </div>
-  <div class="p-4">
-    <canvas id="et0Chart" width="600" height="300" class="mb-4 bg-card p-2 rounded-lg shadow"></canvas>
-    <div id="heatmap" class="mb-4"></div>
-    <table id="dataTable" class="min-w-full border bg-card rounded-lg"></table>
+  <div class="max-w-3xl mx-auto bg-card rounded-lg shadow p-4 my-4">
+    <h1 class="app-title text font-bold mb-4">
+      Plant Analytics
+      <a href="index.html" class="bg-primary text-white rounded-md px-4 py-2 ml-auto">Home</a>
+    </h1>
+
+    <h2 class="font-semibold mb-2">Filters</h2>
+    <div class="flex flex-wrap gap-2 mb-4">
+      <select id="plantSelect" class="border rounded-md p-2"></select>
+      <input type="date" id="startDate" class="border rounded-md p-2">
+      <input type="date" id="endDate" class="border rounded-md p-2">
+      <button id="refresh" class="bg-primary text-white rounded-md px-3 py-2">Show</button>
+    </div>
+
+    <h2 class="font-semibold mb-2">ET₀ Chart</h2>
+    <div class="bg-gray-50 p-4 rounded-lg mb-4">
+      <canvas id="et0Chart" width="600" height="300" class="mb-4"></canvas>
+      <div id="heatmap" class=""></div>
+    </div>
+
+    <h2 class="font-semibold mb-2">Data</h2>
+    <table id="dataTable" class="min-w-full text-sm w-full border-collapse"></table>
   </div>
   <script type="module" src="analytics.js"></script>
   <script>

--- a/analytics.js
+++ b/analytics.js
@@ -60,14 +60,21 @@ function fillTable(data) {
   const tbl = document.getElementById('dataTable');
   tbl.innerHTML = '';
   if (data.length === 0) return;
-  const head = document.createElement('tr');
-  head.innerHTML = '<th>Date</th><th>ET₀ (mm)</th><th>Water (mL)</th>';
-  tbl.appendChild(head);
+  const thead = document.createElement('thead');
+  thead.className = 'bg-gray-50';
+  thead.innerHTML =
+    '<tr><th class="px-3 py-2 text-left">Date</th><th class="px-3 py-2 text-left">ET₀ (mm)</th><th class="px-3 py-2 text-left">Water (mL)</th></tr>';
+  tbl.appendChild(thead);
+  const tbody = document.createElement('tbody');
   data.forEach(r => {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${r.date}</td><td>${r.et0_mm}</td><td>${r.water_ml}</td>`;
-    tbl.appendChild(tr);
+    tr.innerHTML =
+      `<td class="px-3 py-2 border-b border-gray-200">${r.date}</td>` +
+      `<td class="px-3 py-2 border-b border-gray-200">${r.et0_mm}</td>` +
+      `<td class="px-3 py-2 border-b border-gray-200">${r.water_ml}</td>`;
+    tbody.appendChild(tr);
   });
+  tbl.appendChild(tbody);
 }
 
 async function loadTimeseries() {


### PR DESCRIPTION
## Summary
- wrap analytics page content in a centered card
- add section headings and sub-cards for chart and table
- style filter controls and table rows to reuse existing look

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686480a737848324ab361ec3b4e41782