### PR TITLE
Update README for OpenFarm suggestion source

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,11 @@ In list or text view you can swipe right on a plant card to complete all due tas
 You can also export your current plant list as JSON or CSV using the download buttons at the top of the page.
 The new **Analytics** link opens a page with charts of historical ET₀ and water use.
 
-The plant form offers live type-ahead suggestions for the name and species fields. These come from [OpenFarm](https://openfarm.cc) and require outbound access to `openfarm.cc`. If no suggestions appear, ensure your firewall or proxy allows requests to that domain or temporarily disable the feature.
+The plant form offers live type-ahead suggestions and thumbnail previews for the
+name and species fields. Both pieces of data are fetched from the
+[OpenFarm](https://openfarm.cc) API. The previous GBIF integration has been
+removed, so the app no longer contacts `api.gbif.org`. Ensure outbound access to
+`openfarm.cc` is allowed or the suggestions and images won't appear.
 
 ## Service Worker
 A small service worker caches the key pages and scripts so the app still opens when you're offline. During development you may need to disable the cache or bump the version in `service-worker.js` to pick up changes.


### PR DESCRIPTION
## Summary
- note that suggestions and thumbnails now come from OpenFarm and require outbound requests to `openfarm.cc`
- mention GBIF removal

## Testing
- `npm test`
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68648268284c8324871ca9b6ecaa6ff7