### PR TITLE
Improve plant analytics navigation and defaults

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -34,7 +34,7 @@
   <div class="max-w-3xl mx-auto bg-card rounded-lg shadow p-4 my-4">
     <h1 class="app-title text font-bold mb-4">
       Plant Analytics
-      <a href="index.html" class="bg-primary text-white rounded-md px-4 py-2 ml-auto">Home</a>
+      <a id="backLink" href="index.html" class="bg-primary text-white rounded-md px-4 py-2 ml-auto">Back to Plant</a>
     </h1>
 
     <h2 class="font-semibold mb-2">Filters</h2>

--- a/analytics.js
+++ b/analytics.js
@@ -3,6 +3,27 @@ let et0Chart;
 const urlParams = new URLSearchParams(window.location.search);
 const initialPlantId = urlParams.get('plant_id');
 
+function setDefaultDatesToCurrentWeek() {
+  const today = new Date();
+  const day = today.getDay(); // 0 = Sunday
+  const start = new Date(today);
+  start.setDate(today.getDate() - ((day + 6) % 7));
+  start.setHours(0,0,0,0);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 6);
+  const toISO = d => d.toISOString().split('T')[0];
+  const startInput = document.getElementById('startDate');
+  const endInput = document.getElementById('endDate');
+  if (startInput && !startInput.value) startInput.value = toISO(start);
+  if (endInput && !endInput.value) endInput.value = toISO(end);
+}
+
+const backLink = document.getElementById('backLink');
+if (backLink && initialPlantId) {
+  backLink.href = `index.html?plant_id=${initialPlantId}#plant-${initialPlantId}`;
+}
+setDefaultDatesToCurrentWeek();
+
 function drawChart(data) {
   const labels = data.map(r => r.date);
   const et0 = data.map(r => parseFloat(r.et0_mm));

--- a/script.js
+++ b/script.js
@@ -8,6 +8,9 @@ import { calculateET0, computeArea, computeRA } from "./js/calc.js";
 import { parseLocalDate, addDays, formatDateShort } from "./js/dates.js";
 import { showToast, toggleLoading } from "./js/dom.js";
 
+const indexParams = new URLSearchParams(window.location.search);
+const focusPlantId = indexParams.get('plant_id');
+
 // show archived plants instead of active ones
 let showArchive = false;
 let archivedCache = null;
@@ -1231,6 +1234,7 @@ async function loadPlants() {
   filtered.forEach(plant => {
     const wrapper = document.createElement('div');
     wrapper.classList.add('plant-card-wrapper');
+    wrapper.id = `plant-${plant.id}`;
 
     const overlay = document.createElement('div');
     overlay.classList.add('swipe-overlay');
@@ -1565,6 +1569,15 @@ async function loadPlants() {
 
     list.appendChild(wrapper);
   });
+
+  if (focusPlantId) {
+    const el = document.getElementById(`plant-${focusPlantId}`);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      el.classList.add('just-updated');
+      setTimeout(() => el.classList.remove('just-updated'), 2000);
+    }
+  }
 
   // refresh room filter and datalist
 


### PR DESCRIPTION
## Summary
- add link in analytics page back to selected plant
- default analytics date filters to the current week
- allow index page to focus on a plant card by id

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68648e980c748324bd404b20c71f26bb