### PR TITLE
Add descending name sort option

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,8 @@
             <option value="all" selected>All Rooms</option>
         </select>
         <select id="sort-toggle" class="border rounded-md">
-            <option value="name">Sort by: Name</option>
+            <option value="name">Sort by: Name (A-Z)</option>
+            <option value="name-desc">Sort by: Name (Z-A)</option>
             <option value="due" selected>Sort by: Due Date</option>
             <option value="added">Sort by: Date Added</option>
         </select>

--- a/script.js
+++ b/script.js
@@ -1225,6 +1225,9 @@ async function loadPlants() {
 
   const sortBy = document.getElementById('sort-toggle').value || 'name';
   filtered.sort((a, b) => {
+    if (sortBy === 'name-desc') {
+      return b.name.localeCompare(a.name);
+    }
     if (sortBy === 'due') {
       return getSoonestDueDate(a) - getSoonestDueDate(b);
     }


### PR DESCRIPTION
## Summary
- allow sorting plant list by Name A-Z or Name Z-A
- handle `name-desc` sort option in script.js

## Testing
- `npm test`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: `composer` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864941560088324a35cfaf3b9dab4b2