### PR TITLE
Fix plant focus URL handling

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -20,7 +20,7 @@ function setDefaultDatesToCurrentWeek() {
 
 const backLink = document.getElementById('backLink');
 if (backLink && initialPlantId) {
-  backLink.href = `index.html?plant_id=${initialPlantId}#plant-${initialPlantId}`;
+  backLink.href = `index.html#plant-${initialPlantId}`;
 }
 setDefaultDatesToCurrentWeek();
 

--- a/script.js
+++ b/script.js
@@ -9,7 +9,13 @@ import { parseLocalDate, addDays, formatDateShort } from "./js/dates.js";
 import { showToast, toggleLoading } from "./js/dom.js";
 
 const indexParams = new URLSearchParams(window.location.search);
-const focusPlantId = indexParams.get('plant_id');
+let focusPlantId = null;
+const hashMatch = location.hash.match(/^#plant-(\d+)/);
+if (hashMatch) {
+  focusPlantId = hashMatch[1];
+} else {
+  focusPlantId = indexParams.get('plant_id');
+}
 
 // show archived plants instead of active ones
 let showArchive = false;
@@ -1582,6 +1588,7 @@ async function loadPlants() {
       el.scrollIntoView({ behavior: 'smooth', block: 'center' });
       el.classList.add('just-updated');
       setTimeout(() => el.classList.remove('just-updated'), 2000);
+      history.replaceState(null, '', location.pathname + '#plant-' + focusPlantId);
     }
   }
 


### PR DESCRIPTION
## Summary
- keep analytics back link anchor-only
- read plant focus from URL hash if available
- update URL hash after scrolling a plant into view

## Testing
- `npm test | tail -n 20`
- `phpunit > /tmp/phpunit.log && tail -n 20 /tmp/phpunit.log`

------
https://chatgpt.com/codex/tasks/task_e_686498a3aabc83249ae2d7ed1d91b3ea