### PR TITLE
Fix autocomplete variable scope and resilient caching

### DIFF
--- a/script.js
+++ b/script.js
@@ -57,6 +57,9 @@ calendarStartDate.setHours(0, 0, 0, 0);
 const iNatCache = new Map();
 const plantInfoCache = new Map();
 
+// DOM elements used across functions
+let suggestionList = null;
+
 
 function debounce(fn, delay = 300) {
   let timer;
@@ -1685,7 +1688,7 @@ async function init(){
   const speciesInput = document.getElementById('species');
   const potHelp = document.getElementById('pot_diameter_help');
   const speciesList = document.getElementById('species-list');
-  const suggestionList = document.getElementById('name-suggestions');
+  suggestionList = document.getElementById('name-suggestions');
   const sciNameInput = document.getElementById('scientific_name');
   const imageUrlInput = document.getElementById('thumbnail_url');
   const previewImg = document.getElementById('name-preview');

--- a/service-worker.js
+++ b/service-worker.js
@@ -10,7 +10,11 @@ const ASSETS = [
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(ASSETS))
+    caches.open(CACHE_NAME).then(cache =>
+      Promise.all(
+        ASSETS.map(asset => cache.add(asset).catch(() => {}))
+      )
+    )
   );
 });
 


### PR DESCRIPTION
## Summary
- move `suggestionList` out of `init()` so lookup works
- fall back gracefully when caching install assets

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686492d30ba48324a298e47a6cc3e650