### PR TITLE
Revise Add Plant form

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,9 @@ In list or text view you can swipe right on a plant card to complete all due tas
 You can also export your current plant list as JSON or CSV using the download buttons at the top of the page.
 The new **Analytics** link opens a page with charts of historical ET₀ and water use.
 
-The plant form offers live type-ahead suggestions and thumbnail previews for the
-name and species fields. Both pieces of data are fetched from the
+The plant form offers live suggestions for scientific names as you type a common
+plant name. Selecting a scientific name fills the field and loads a thumbnail
+preview fetched from the
 [iNaturalist](https://api.inaturalist.org) API. The previous OpenFarm integration
 was removed because that service is no longer available. Ensure outbound access
 to `api.inaturalist.org` is allowed or the suggestions and images won't appear.

--- a/index.html
+++ b/index.html
@@ -57,7 +57,6 @@
                 <label for="name" class="block mb-1">Plant Name <span class="required-star" aria-hidden="true">*</span></label>
                 <div class="relative">
                     <input type="text" name="name" id="name" placeholder="Plant Name" class="w-full border rounded-md p-2" autocomplete="off" required />
-                    <ul id="name-suggestions" class="suggestions"></ul>
                 </div>
                 <input type="hidden" name="scientific_name" id="scientific_name">
                 <input type="hidden" name="thumbnail_url" id="thumbnail_url">


### PR DESCRIPTION
## Summary
- remove Plant Name autocomplete list
- fetch scientific name options as user types plant name
- load thumbnail preview when choosing a scientific name
- document updated behavior in README

## Testing
- `npm test`
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68649ba366c883248e8a2d78c35f1358