### PR TITLE
Add focusPlantId hash test

### DIFF
--- a/__tests__/focus.test.js
+++ b/__tests__/focus.test.js
@@ -1,0 +1,18 @@
+import { jest } from '@jest/globals';
+
+// Prevent init() from running by faking loading state
+beforeEach(() => {
+  Object.defineProperty(document, 'readyState', {
+    configurable: true,
+    get: () => 'loading',
+  });
+});
+
+test('focusPlantId set from hash', async () => {
+  window.location.hash = '#plant-5';
+  let mod;
+  await jest.isolateModulesAsync(async () => {
+    mod = await import('../script.js');
+  });
+  expect(mod.focusPlantId).toBe('5');
+});

--- a/script.js
+++ b/script.js
@@ -2070,4 +2070,4 @@ if (document.readyState === 'loading') {
   init();
 }
 
-export { loadCalendar };
+export { loadCalendar, focusPlantId };


### PR DESCRIPTION
## Summary
- export `focusPlantId` from `script.js`
- test that hash `#plant-5` sets `focusPlantId`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68649d5ce9c483249bdcc485ad161d55