### PR TITLE
Add tasks view with mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,10 @@
     </form>
 
     <div class="my-4 flex flex-wrap items-center gap-4 p-4">
+        <div id="mode-toggle" class="view-toggle-group inline-flex rounded-lg border border-gray-300 overflow-hidden">
+            <button type="button" data-mode="tasks" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">Tasks</button>
+            <button type="button" data-mode="library" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">Library</button>
+        </div>
         <div id="filter-container" class="overflow-container flex items-center gap-2">
             <button id="filter-btn" class="bg-gray-200 rounded-md px-4 py-2 inline-flex items-center gap-2"></button>
             <div id="filter-chips" class="flex flex-wrap gap-2"></div>


### PR DESCRIPTION
## Summary
- add Tasks/Library toggle in the toolbar
- support mode state in localStorage
- show upcoming tasks when in Tasks mode
- update filter chip logic for mode defaults

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6864a42dfb50832494b53149333faadd