### PR TITLE
Update service worker for analytics page

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,7 +1,9 @@
 const CACHE_NAME = 'plant-tracker-v3';
 const ASSETS = [
   './index.html',
+  './analytics.html',
   './script.js',
+  './analytics.js',
   './style.css',
   './favicon.svg',
   './manifest.json',
@@ -41,7 +43,11 @@ self.addEventListener('fetch', event => {
   }
   if (req.mode === 'navigate') {
     event.respondWith(
-      caches.match('./index.html').then(resp => resp || fetch(req))
+      fetch(req).catch(() => {
+        const fallback = req.url.includes('analytics') ?
+          './analytics.html' : './index.html';
+        return caches.match(fallback);
+      })
     );
     return;
   }


### PR DESCRIPTION
## Summary
- cache analytics files in service worker
- handle offline navigation to analytics.html

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6864a543943483248c3fddb94f506cfa