### PR TITLE
Refine toolbar filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
         </div>
     </form>
 
-    <div class="my-4 flex flex-wrap items-center gap-4 p-4">
+    <div id="toolbar" class="my-4 flex flex-wrap items-center gap-4 p-4">
         <div id="mode-toggle" class="view-toggle-group inline-flex rounded-lg border border-gray-300 overflow-hidden">
             <button type="button" data-mode="tasks" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">Tasks</button>
             <button type="button" data-mode="library" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">Library</button>
@@ -170,20 +170,20 @@
                     <option value="all" selected>All Rooms</option>
                 </select>
                 <select id="due-filter" class="border rounded-md">
-                    <option value="all">Show: All</option>
-                    <option value="water">Needs Watering</option>
-                    <option value="fert">Needs Fertilizing</option>
+                    <option value="all">Due: All</option>
+                    <option value="water">Watering Due</option>
+                    <option value="fert">Fertilizing Due</option>
                     <option value="any" selected>Needs Care</option>
                 </select>
-                <select id="sort-toggle" class="border rounded-md">
-                    <option value="name">Sort by: Name (A-Z)</option>
-                    <option value="name-desc">Sort by: Name (Z-A)</option>
-                    <option value="due" selected>Sort by: Due Date</option>
-                    <option value="added">Sort by: Date Added</option>
-                </select>
             </div>
+            <select id="sort-toggle" class="border rounded-md">
+                <option value="name">Name (A-Z)</option>
+                <option value="name-desc">Name (Z-A)</option>
+                <option value="due" selected>Due Date</option>
+                <option value="added">Date Added</option>
+            </select>
         </div>
-        <div id="view-toggle" class="view-toggle-group inline-flex rounded-lg border border-gray-300 overflow-hidden">
+        <div id="view-toggle" class="view-toggle-group inline-flex rounded-lg border border-gray-300 overflow-hidden ml-auto">
             <button type="button" data-view="grid" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
             <button type="button" data-view="list" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
             <button type="button" data-view="text" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>

--- a/script.js
+++ b/script.js
@@ -513,8 +513,8 @@ function updateFilterChips() {
   const room = document.getElementById('room-filter')?.value || 'all';
   const due = document.getElementById('due-filter')?.value || (mainMode === 'tasks' ? 'any' : 'all');
   const sort = document.getElementById('sort-toggle')?.value || (mainMode === 'tasks' ? 'due' : 'name');
-  const dueLabels = { water: 'Needs Watering', fert: 'Needs Fertilizing', any: 'Needs Care', all: 'All' };
-  const sortLabels = { 'name': 'A–Z', 'name-desc': 'Z–A', 'due': 'Due Date', 'added': 'Date Added' };
+  const dueLabels = { water: 'Watering Due', fert: 'Fertilizing Due', any: 'Needs Care', all: 'All' };
+  const sortLabels = { 'name': 'Name \u25B2', 'name-desc': 'Name \u25BC', 'due': 'Due Date', 'added': 'Date Added' };
   function addChip(type, label) {
     const span = document.createElement('span');
     span.className = 'filter-chip';
@@ -536,8 +536,8 @@ function updateFilterChips() {
   if (room !== 'all') addChip('room', room);
   const defaultDue = mainMode === 'tasks' ? 'any' : 'all';
   const defaultSort = mainMode === 'tasks' ? 'due' : 'name';
-  if (due !== defaultDue) addChip('due', dueLabels[due] || due);
-  if (sort !== defaultSort) addChip('sort', sortLabels[sort] || sort);
+  if (due !== defaultDue) addChip('due', `Due: ${dueLabels[due] || due}`);
+  if (sort !== defaultSort) addChip('sort', `Sort: ${sortLabels[sort] || sort}`);
 }
 
 

--- a/style.css
+++ b/style.css
@@ -990,11 +990,18 @@ button:focus {
   position: relative;
 }
 
+#toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: calc(var(--spacing) * 2);
+}
+
 .overflow-menu {
   display: none;
   position: absolute;
   bottom: calc(100% + var(--spacing));
-  right: 0;
+  left: 0;
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
@@ -1005,8 +1012,28 @@ button:focus {
   gap: var(--spacing);
 }
 
+.overflow-menu::before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 1rem;
+  border-width: 6px;
+  border-style: solid;
+  border-color: var(--color-border) transparent transparent transparent;
+}
+.overflow-menu::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 1rem;
+  transform: translateY(-1px);
+  border-width: 5px;
+  border-style: solid;
+  border-color: var(--color-surface) transparent transparent transparent;
+}
+
 .filter-chip {
-  background: var(--color-surface);
+  background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
   padding: 0.25rem 0.5rem;


### PR DESCRIPTION
## Summary
- reposition filter popover and add arrow
- lighten filter chips and group toolbar layout
- rename due filter options and expose sort dropdown
- show clearer text on filter pills

## Testing
- `npm test` *(fails: cannot find module 'jest')*
- `vendor/bin/phpunit tests` *(fails: phpunit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864a75f27a0832493c34a116edabb81