### PR TITLE
Fix thumbnail loss on plant edits

### DIFF
--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -57,6 +57,21 @@ if ($photo_url === '' && (!isset($_FILES['photo']) || $_FILES['photo']['error'] 
     }
 }
 
+// If no thumbnail URL is provided, retain the existing one
+if ($thumbnail_url === '') {
+    $stmt = $conn->prepare("SELECT thumbnail_url FROM plants WHERE id = ?");
+    if ($stmt) {
+        $stmt->bind_param('i', $id);
+        if ($stmt->execute()) {
+            $stmt->bind_result($existingThumb);
+            if ($stmt->fetch()) {
+                $thumbnail_url = $existingThumb;
+            }
+        }
+        $stmt->close();
+    }
+}
+
 // further validation
 if ($species !== '' && !preg_match("/^[\p{L}0-9\s.'-]{1,100}$/u", $species)) {
     $errors[] = 'Invalid species';

--- a/script.js
+++ b/script.js
@@ -976,6 +976,8 @@ async function updatePlantInline(plant, field, newValue) {
   data.append('last_watered', plant.last_watered || '');
   data.append('last_fertilized', plant.last_fertilized || '');
   data.append('photo_url', plant.photo_url || '');
+  data.append('scientific_name', plant.scientific_name || '');
+  data.append('thumbnail_url', plant.thumbnail_url || '');
 
   data.set(field, newValue);
 
@@ -1007,6 +1009,8 @@ async function updatePlantPhoto(plant, file) {
   data.append('room', plant.room);
   data.append('last_watered', plant.last_watered || '');
   data.append('last_fertilized', plant.last_fertilized || '');
+  data.append('scientific_name', plant.scientific_name || '');
+  data.append('thumbnail_url', plant.thumbnail_url || '');
   data.append('photo', file);
 
   toggleLoading(true);


### PR DESCRIPTION
## Summary
- retain existing thumbnail_url in `update_plant.php` when none supplied
- include scientific_name and thumbnail_url when saving inline edits
- send scientific_name and thumbnail_url when updating the photo

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6864aaeefe108324a4b5b65932e6b7b2