### PR TITLE
Restore auto-loading analytics

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1,5 +1,7 @@
 const ctx = document.getElementById('et0Chart').getContext('2d');
 let et0Chart;
+const urlParams = new URLSearchParams(window.location.search);
+const initialPlantId = urlParams.get('plant_id');
 
 function setDefaultDatesToCurrentWeek() {
   const today = new Date();
@@ -17,6 +19,9 @@ function setDefaultDatesToCurrentWeek() {
 }
 
 const backLink = document.getElementById('backLink');
+if (backLink && initialPlantId) {
+  backLink.href = `index.html#plant-${initialPlantId}`;
+}
 setDefaultDatesToCurrentWeek();
 
 function drawChart(data) {
@@ -123,6 +128,10 @@ async function loadPlants() {
     opt.textContent = p.name;
     sel.appendChild(opt);
   });
+  if (initialPlantId) {
+    sel.value = initialPlantId;
+    await loadTimeseries();
+  }
 }
 
 document.getElementById('refresh').addEventListener('click', loadTimeseries);

--- a/script.js
+++ b/script.js
@@ -1614,9 +1614,7 @@ async function loadPlants() {
     analyticsLink.classList.add('action-btn');
     analyticsLink.innerHTML = ICONS.analytics + '<span class="visually-hidden">Analytics</span>';
     analyticsLink.title = 'Analytics';
-    analyticsLink.href = 'analytics.html';
-    analyticsLink.target = '_blank';
-    analyticsLink.rel = 'noopener';
+    analyticsLink.href = `analytics.html?plant_id=${plant.id}`;
     actionsDiv.appendChild(analyticsLink);
 
     const fileInput = document.createElement('input');


### PR DESCRIPTION
## Summary
- pass plant_id when clicking Analytics link
- auto-select plant in analytics based on URL parameter

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6864af9d808c8324b3b4a40b02c2a12a