### PR TITLE
Clear plant highlight hash on first click

### DIFF
--- a/script.js
+++ b/script.js
@@ -1736,6 +1736,12 @@ async function loadPlants() {
       el.classList.add('just-updated');
       setTimeout(() => el.classList.remove('just-updated'), 2000);
       history.replaceState(null, '', location.pathname + '#plant-' + focusPlantId);
+
+      const clearHash = () => {
+        history.replaceState(null, '', location.pathname);
+        document.removeEventListener('click', clearHash);
+      };
+      document.addEventListener('click', clearHash, { once: true });
     }
   }
 


### PR DESCRIPTION
## Summary
- clear `#plant-{id}` from the URL after the user clicks anywhere

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68650ddcb0808324a875c3e641597c52