### PR TITLE
Fix leftover thumbnail when resetting add/edit form

### DIFF
--- a/script.js
+++ b/script.js
@@ -1164,6 +1164,13 @@ function resetForm() {
   }
   const taxInfo = document.getElementById('taxonomy-info');
   if (taxInfo) taxInfo.innerHTML = '';
+  const thumbInput = document.getElementById('thumbnail_url');
+  if (thumbInput) thumbInput.value = '';
+  const previewImg = document.getElementById('name-preview');
+  if (previewImg) {
+    previewImg.src = '';
+    previewImg.classList.add('hidden');
+  }
   const photoInput = document.getElementById('photo');
   if (photoInput) photoInput.value = '';
   const photoUrlInput = document.getElementById('photo_url');


### PR DESCRIPTION
## Summary
- clear the thumbnail URL and preview image when resetting the plant form

## Testing
- `npm test` *(fails: Cannot find module '/workspace/plant-tracker/node_modules/.bin/jest')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68650f4012688324ba71cb464c37af53