### PR TITLE
Fix clearing focusPlantId

### DIFF
--- a/__tests__/focus.test.js
+++ b/__tests__/focus.test.js
@@ -16,3 +16,48 @@ test('focusPlantId set from hash', async () => {
   });
   expect(mod.focusPlantId).toBe('5');
 });
+
+test('clear hash resets focusPlantId and prevents URL updates', async () => {
+  window.location.hash = '#plant-5';
+  document.body.innerHTML = `
+    <div id="plant-grid"></div>
+    <select id="room-filter"><option value="all">All</option></select>
+    <input id="search-input" value="" />
+    <div id="summary"></div>
+    <select id="sort-toggle"></select>
+  `;
+
+  HTMLElement.prototype.scrollIntoView = jest.fn();
+
+  global.fetch = jest.fn().mockResolvedValue({
+    json: () =>
+      Promise.resolve([
+        {
+          id: 5,
+          name: 'Test',
+          species: 'Spec',
+          room: 'Room1',
+          watering_frequency: 7,
+          fertilizing_frequency: 7,
+          last_watered: '2023-01-01',
+          last_fertilized: '2023-01-01',
+          created_at: '2023-01-01',
+        },
+      ]),
+  });
+
+  let mod;
+  await jest.isolateModulesAsync(async () => {
+    mod = await import('../script.js');
+  });
+
+  await mod.loadPlants();
+  expect(window.location.hash).toBe('#plant-5');
+
+  document.dispatchEvent(new Event('click'));
+  expect(mod.focusPlantId).toBeNull();
+  expect(window.location.hash).toBe('');
+
+  await mod.loadPlants();
+  expect(window.location.hash).toBe('');
+});

--- a/script.js
+++ b/script.js
@@ -1746,6 +1746,7 @@ async function loadPlants() {
 
       const clearHash = () => {
         history.replaceState(null, '', location.pathname);
+        focusPlantId = null;
         document.removeEventListener('click', clearHash);
       };
       document.addEventListener('click', clearHash, { once: true });
@@ -2230,4 +2231,4 @@ if (document.readyState === 'loading') {
   init();
 }
 
-export { loadCalendar, focusPlantId };
+export { loadCalendar, focusPlantId, loadPlants };


### PR DESCRIPTION
## Summary
- reset `focusPlantId` when clearing the URL hash
- export `loadPlants` for testing
- test clearing the hash behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865132ca5d88324928c3303fbcd8568