### PR TITLE
Enhance filter menu UX

### DIFF
--- a/script.js
+++ b/script.js
@@ -422,6 +422,7 @@ const ICONS = {
   search: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>',
   calendar: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>',
   rain: '<svg class="icon icon-rain" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16" y1="13" x2="16" y2="21"/><line x1="8" y1="13" x2="8" y2="21"/><line x1="12" y1="15" x2="12" y2="23"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg>',
+  room: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21V3h18v18"/><path d="M9 21V9h6v12"/></svg>',
   download: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>',
   left: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>',
   right: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>',
@@ -515,10 +516,17 @@ function updateFilterChips() {
   const sort = document.getElementById('sort-toggle')?.value || (mainMode === 'tasks' ? 'due' : 'name');
   const statusLabels = { water: 'Watering', fert: 'Fertilizing', any: 'Needs Care', all: 'All' };
   const sortLabels = { 'name': 'Name \u25B2', 'name-desc': 'Name \u25BC', 'due': 'Due Date', 'added': 'Date Added' };
-  function addChip(type, label) {
+  function addChip(type, label, icon, extraClass) {
     const span = document.createElement('span');
     span.className = 'filter-chip';
-    span.textContent = label;
+    span.classList.add(`${type}-chip`);
+    if (extraClass) span.classList.add(extraClass);
+    if (icon) {
+      const iconWrap = document.createElement('span');
+      iconWrap.innerHTML = icon;
+      span.appendChild(iconWrap);
+    }
+    span.appendChild(document.createTextNode(' ' + label));
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.innerHTML = ICONS.cancel;
@@ -533,16 +541,38 @@ function updateFilterChips() {
     span.appendChild(btn);
     wrap.appendChild(span);
   }
-  if (room !== 'all') addChip('room', room);
+  if (room !== 'all') addChip('room', room, ICONS.room);
   const defaultStatus = mainMode === 'tasks' ? 'any' : 'all';
   const defaultSort = mainMode === 'tasks' ? 'due' : 'name';
-  if (status !== defaultStatus) addChip('status', `Status: ${statusLabels[status] || status}`);
-  if (sort !== defaultSort) addChip('sort', `Sort: ${sortLabels[sort] || sort}`);
+  if (status !== defaultStatus) {
+    const icon = status === 'water' ? ICONS.water : status === 'fert' ? ICONS.fert : ICONS.filter;
+    const cls = status === 'water' ? 'status-water-chip' : status === 'fert' ? 'status-fert-chip' : 'status-any-chip';
+    addChip('status', `Status: ${statusLabels[status] || status}`, icon, cls);
+  }
+  if (sort !== defaultSort) addChip('sort', `Sort: ${sortLabels[sort] || sort}`, ICONS.list);
 
   const summary = document.getElementById('filter-summary');
   const activeCount = wrap.children.length;
   if (summary) {
     summary.textContent = activeCount ? `${activeCount} filter${activeCount > 1 ? 's' : ''} applied` : 'No filters';
+  }
+  if (activeCount > 1) {
+    const reset = document.createElement('span');
+    reset.className = 'filter-chip reset-chip';
+    reset.textContent = 'Clear All';
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.innerHTML = ICONS.cancel;
+    btn.addEventListener('click', () => {
+      document.getElementById('room-filter').value = 'all';
+      document.getElementById('status-filter').value = defaultStatus;
+      document.getElementById('sort-toggle').value = defaultSort;
+      saveFilterPrefs();
+      updateFilterChips();
+      loadPlants();
+    });
+    reset.appendChild(btn);
+    wrap.appendChild(reset);
   }
 }
 
@@ -1256,6 +1286,17 @@ async function loadPlants() {
   const res = await fetch(`api/get_plants.php${showArchive ? '?archived=1' : ''}`);
   const plants = await res.json();
   plantCache = plants;
+  const roomCounts = {};
+  const statusCounts = { water: 0, fert: 0, any: 0 };
+  const today = new Date();
+  plants.forEach(p => {
+    if (p.room) roomCounts[p.room] = (roomCounts[p.room] || 0) + 1;
+    const w = needsWatering(p, today);
+    const f = needsFertilizing(p, today);
+    if (w) statusCounts.water++;
+    if (f) statusCounts.fert++;
+    if (w || f) statusCounts.any++;
+  });
   const list = document.getElementById('plant-grid');
   if (list) {
     list.classList.toggle('list-view', viewMode === 'list');
@@ -1292,7 +1333,6 @@ async function loadPlants() {
     }
   }
   const searchQuery = document.getElementById('search-input').value.trim().toLowerCase();
-  const today = new Date();
   const todayStr = today.toLocaleDateString(undefined, {
     year: 'numeric',
     month: 'short',
@@ -1422,15 +1462,15 @@ async function loadPlants() {
     let urgencyClass = '';
     let urgencyText = '';
     if (!showArchive) {
-      if (soonest < startOfToday) {
-        card.classList.add('due-overdue');
-        urgencyClass = 'urgency-overdue';
-        const overdueDays = Math.floor((startOfToday - soonest) / 86400000);
-        urgencyText = `Overdue by ${overdueDays} day${overdueDays !== 1 ? 's' : ''}`;
-      } else if (soonest < startOfTomorrow) {
-        card.classList.add('due-today');
-        urgencyClass = 'urgency-today';
-        urgencyText = 'Due Today';
+        if (soonest < startOfToday) {
+          card.classList.add('due-overdue', 'animate-alert');
+          urgencyClass = 'urgency-overdue';
+          const overdueDays = Math.floor((startOfToday - soonest) / 86400000);
+          urgencyText = `Overdue by ${overdueDays} day${overdueDays !== 1 ? 's' : ''}`;
+        } else if (soonest < startOfTomorrow) {
+          card.classList.add('due-today', 'animate-alert');
+          urgencyClass = 'urgency-today';
+          urgencyText = 'Due Today';
       } else if (soonest < startOfDayAfterTomorrow) {
         card.classList.add('due-future');
         urgencyClass = 'urgency-future';
@@ -1728,6 +1768,9 @@ async function loadPlants() {
     actionsDiv.appendChild(fileInput);
     card.appendChild(actionsDiv);
     wrapper.appendChild(card);
+    if (card.classList.contains('animate-alert')) {
+      setTimeout(() => card.classList.remove('animate-alert'), 600);
+    }
 
     if (viewMode === 'list') {
       enableSwipeComplete(card, overlay, plant, waterDue, fertDue);
@@ -1763,12 +1806,11 @@ async function loadPlants() {
   const filter = document.getElementById('room-filter');
   if (filter) {
     const current = filter.value;
-    filter.innerHTML = '<option value="all">All Rooms</option>';
+    filter.innerHTML = `<option value="all">All Rooms (${plants.length})</option>`;
     rooms.forEach(r => {
-
       const opt = document.createElement('option');
       opt.value = r;
-      opt.textContent = r;
+      opt.textContent = `${r} (${roomCounts[r] || 0})`;
       filter.appendChild(opt);
     });
 
@@ -1785,6 +1827,19 @@ async function loadPlants() {
       opt.value = r;
       datalist.appendChild(opt);
     });
+  }
+
+  const dueFilterEl = document.getElementById('status-filter');
+  if (dueFilterEl) {
+    const current = dueFilterEl.value;
+    dueFilterEl.innerHTML = `
+      <option value="all">Status: All (${plants.length})</option>
+      <option value="water">Watering (${statusCounts.water})</option>
+      <option value="fert">Fertilizing (${statusCounts.fert})</option>
+      <option value="any">Needs Care (${statusCounts.any})</option>`;
+    if (Array.from(dueFilterEl.options).some(o => o.value === current)) {
+      dueFilterEl.value = current;
+    }
   }
 
   checkArchivedLink(plants);

--- a/style.css
+++ b/style.css
@@ -442,6 +442,12 @@ button:focus {
   0%, 100% { transform: scale(1); }
   50% { transform: scale(1.1); }
 }
+
+@keyframes shake {
+  0%,100% { transform: translateX(0); }
+  25% { transform: translateX(-2px); }
+  75% { transform: translateX(2px); }
+}
 #undo-banner {
   position: fixed;
   bottom: calc(var(--spacing) * 1.25);
@@ -1014,6 +1020,10 @@ button:focus {
   flex-wrap: wrap;
   align-items: center;
   gap: calc(var(--spacing) * 2);
+  position: sticky;
+  top: 0;
+  background: var(--color-bg);
+  z-index: 20;
 }
 
 #filter-container {
@@ -1034,6 +1044,9 @@ button:focus {
   z-index: 10;
   flex-direction: column;
   gap: var(--spacing);
+  opacity: 0;
+  transform: translateY(-5px);
+  transition: opacity 0.2s ease-out, transform 0.2s ease-out;
 }
 
 .overflow-menu::before {
@@ -1065,6 +1078,26 @@ button:focus {
   align-items: center;
   gap: 2px;
   font-size: 0.85rem;
+}
+.room-chip {
+  background: var(--color-edit-bg);
+}
+.status-water-chip {
+  background: var(--color-water-bg);
+  color: var(--color-water);
+}
+.status-fert-chip {
+  background: var(--color-sprout-bg);
+  color: var(--color-plant);
+}
+.status-any-chip {
+  background: var(--color-warning-bg);
+}
+.sort-chip {
+  background: var(--color-chip-bg);
+}
+.reset-chip {
+  background: var(--color-warning-bg);
 }
 .filter-chip button {
   border: none;
@@ -1101,6 +1134,8 @@ button:focus {
 
 .overflow-menu.show {
   display: flex;
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .plant-info {
@@ -1360,6 +1395,14 @@ button:focus {
 .urgency-future {
   background-color: rgba(56, 161, 105, 0.9);
   transform-origin: right top;
+}
+
+.animate-alert {
+  animation: shake 0.4s ease-in-out;
+}
+
+.plant-card:not(.due-overdue):not(.due-today):not(.due-future) {
+  opacity: 0.6;
 }
 
 .loading-overlay {


### PR DESCRIPTION
## Summary
- animate filter dropdown with arrow pointer
- show active filter chips with icons and add `Clear All`
- surface room and status counts in dropdowns
- keep toolbar fixed at the top
- highlight urgent cards and fade low priority items

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6865140422d48324b23eee55dcb6a31a