### PR TITLE
Improve iNaturalist thumbnail quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,11 @@ It links back to the main interface using the same `#plant-{id}` fragment so you
 The plant form offers live suggestions for scientific names as you type a common
 plant name. Selecting a scientific name fills the field and loads a thumbnail
 preview fetched from the
-[iNaturalist](https://api.inaturalist.org) API. The previous OpenFarm integration
-was removed because that service is no longer available. Ensure outbound access
-to `api.inaturalist.org` is allowed or the suggestions and images won't appear.
+[iNaturalist](https://api.inaturalist.org) API. Thumbnails now use the API's
+`medium_url` variant (~368×500 pixels) so they remain sharp when displayed.
+The previous OpenFarm integration was removed because that service is no longer
+available. Ensure outbound access to `api.inaturalist.org` is allowed or the
+suggestions and images won't appear.
 
 ## Service Worker
 A small service worker caches the key pages and scripts so the app still opens when you're offline. During development you may need to disable the cache or bump the version in `service-worker.js` to pick up changes.

--- a/script.js
+++ b/script.js
@@ -278,11 +278,16 @@ async function showTaxonomyInfo(name) {
       if (detailRes.ok) {
         const detailJson = await detailRes.json();
         const detail = (detailJson.results || [])[0] || {};
-        photos = (detail.taxon_photos || []).map(tp => tp.photo && tp.photo.square_url).filter(Boolean);
+        // prefer the medium variant for sharper thumbnails, falling back to
+        // square if it is unavailable
+        photos = (detail.taxon_photos || []).map(tp => {
+          const p = tp.photo || {};
+          return p.medium_url || p.square_url;
+        }).filter(Boolean);
       }
     } catch (e) {}
-    if (!photos.length && taxon.default_photo && taxon.default_photo.square_url) {
-      photos = [taxon.default_photo.square_url];
+    if (!photos.length && taxon.default_photo) {
+      photos = [taxon.default_photo.medium_url || taxon.default_photo.square_url];
     }
 
     let img = photos[0] || '';
@@ -337,7 +342,7 @@ async function lookupPlants(query) {
       const li = document.createElement('li');
       li.textContent = taxon.preferred_common_name || taxon.name;
       li.dataset.sci = taxon.name || '';
-      li.dataset.img = (taxon.default_photo && taxon.default_photo.square_url) || '';
+      li.dataset.img = (taxon.default_photo && (taxon.default_photo.medium_url || taxon.default_photo.square_url)) || '';
       suggestionList.appendChild(li);
     });
   } catch (e) {


### PR DESCRIPTION
## Summary
- clarify README on how iNaturalist thumbnails use the `medium_url` variant (~368x500px)
- document thumbnail preference in `script.js`

## Testing
- `phpunit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686513154d8c83248e93bb80378c3ab6