### PR TITLE
Add plant list update animation

### DIFF
--- a/script.js
+++ b/script.js
@@ -1336,6 +1336,8 @@ async function loadPlants() {
   const startOfTomorrow = addDays(startOfToday,1);
   const startOfDayAfterTomorrow = addDays(startOfTomorrow,1);
 
+  if (list) list.classList.add('list-updating');
+
   list.innerHTML = '';
   const filtered = plants.filter(plant => {
     if (selectedRoom !== 'all' && plant.room !== selectedRoom) return false;
@@ -1833,6 +1835,9 @@ async function loadPlants() {
 
   checkArchivedLink(plants);
   loadCalendar(plants);
+  if (list) {
+    requestAnimationFrame(() => list.classList.remove('list-updating'));
+  }
 }
 
 async function checkArchivedLink(plantsList) {

--- a/style.css
+++ b/style.css
@@ -947,6 +947,14 @@ button:focus {
 .plant-card-wrapper {
   position: relative;
   --swipe-progress: 0;
+  opacity: 1;
+  transform: translateY(0);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+#plant-grid.list-updating .plant-card-wrapper {
+  opacity: 0;
+  transform: translateY(10px);
 }
 
 .swipe-overlay {


### PR DESCRIPTION
## Summary
- animate plant cards when the list refreshes
- trigger transition from JS by toggling a `list-updating` class

## Testing
- `npm test` *(fails: cannot find module `jest`)*

------
https://chatgpt.com/codex/tasks/task_e_6865274e66c08324a6648fb4eb418cd9