### PR TITLE
Add urgent tasks banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,6 +187,7 @@
             <button type="button" data-view="text" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
         </div>
     </div>
+    <div id="urgent-bar" class="summary-banner"></div>
     <div id="rainfall-info" class="p-4 bg-card rounded-lg mb-4 hidden"></div>
 
     <!-- Undo delete snackbar -->

--- a/script.js
+++ b/script.js
@@ -427,6 +427,7 @@ const ICONS = {
   rain: '<svg class="icon icon-rain" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="16" y1="13" x2="16" y2="21"/><line x1="8" y1="13" x2="8" y2="21"/><line x1="12" y1="15" x2="12" y2="23"/><path d="M20.39 18.39A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.3"/></svg>',
   room: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21V3h18v18"/><path d="M9 21V9h6v12"/></svg>',
   download: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>',
+  alert: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a1 1 0 0 0 .86 1.5h18.64a1 1 0 0 0 .86-1.5L13.71 3.86a1 1 0 0 0-1.72 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>',
   left: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>',
   right: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>',
   list: '<svg class="icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3" y2="6"/><line x1="3" y1="12" x2="3" y2="12"/><line x1="3" y1="18" x2="3" y2="18"/></svg>',
@@ -1335,6 +1336,22 @@ async function loadPlants() {
   startOfToday.setHours(0,0,0,0);
   const startOfTomorrow = addDays(startOfToday,1);
   const startOfDayAfterTomorrow = addDays(startOfTomorrow,1);
+
+  let dueToday = 0;
+  plants.forEach(p => {
+    const soonest = getSoonestDueDate(p);
+    if (soonest >= startOfToday && soonest < startOfTomorrow) dueToday++;
+  });
+  const urgentEl = document.getElementById('urgent-bar');
+  if (urgentEl) {
+    if (dueToday > 0) {
+      urgentEl.innerHTML = `${ICONS.alert} ${dueToday} task${dueToday !== 1 ? 's' : ''} due today`;
+      urgentEl.classList.add('show');
+    } else {
+      urgentEl.classList.remove('show');
+      urgentEl.innerHTML = '';
+    }
+  }
 
   list.innerHTML = '';
   const filtered = plants.filter(plant => {


### PR DESCRIPTION
## Summary
- insert `urgent-bar` summary banner
- show today's due count in the banner via `loadPlants`
- include alert icon for urgent tasks

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6865274fdf908324b41b4e0778cca70e