### PR TITLE
Place sort dropdown in filter panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,14 +173,14 @@
                     <option value="fert">Fertilizing</option>
                     <option value="any" selected>Needs Care</option>
                 </select>
+                <select id="sort-toggle" class="border rounded-md">
+                    <option value="name">Name (A-Z)</option>
+                    <option value="name-desc">Name (Z-A)</option>
+                    <option value="due" selected>Due Date</option>
+                    <option value="added">Date Added</option>
+                </select>
             </div>
         </div>
-        <select id="sort-toggle" class="border rounded-md mr-4">
-            <option value="name">Name (A-Z)</option>
-            <option value="name-desc">Name (Z-A)</option>
-            <option value="due" selected>Due Date</option>
-            <option value="added">Date Added</option>
-        </select>
         <div id="view-toggle" class="view-toggle-group inline-flex rounded-lg border border-gray-300 overflow-hidden ml-auto">
             <button type="button" data-view="grid" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
             <button type="button" data-view="list" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>

--- a/style.css
+++ b/style.css
@@ -1130,6 +1130,12 @@ button:focus {
     display: inline-flex;
     align-items: center;
   }
+  #sort-toggle {
+    display: none;
+  }
+  #filter-panel #sort-toggle {
+    display: block;
+  }
 }
 
 .overflow-menu.show {


### PR DESCRIPTION
## Summary
- move the sort select into the `filter-panel`
- hide the standalone dropdown on narrow screens

## Testing
- `npm test`
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686527533e2c83249526f1fe77eadae0