### PR TITLE
Add quick filter chips

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,8 +162,9 @@
             <button type="button" data-mode="tasks" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">Tasks</button>
             <button type="button" data-mode="library" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">All Plants</button>
         </div>
-        <div id="filter-container" class="overflow-container flex items-center gap-2 mr-4 relative">
+        <div id="filter-container" class="overflow-container flex flex-col items-start gap-2 mr-4 relative">
             <button id="filter-btn" class="bg-gray-200 rounded-md px-4 py-2 inline-flex items-center gap-2"></button>
+            <div id="quick-filters" class="flex flex-wrap gap-2"></div>
             <div id="filter-chips" class="flex flex-wrap gap-2"></div>
             <button id="filter-summary" class="text-sm filter-summary"></button>
             <div id="filter-panel" class="overflow-menu">

--- a/style.css
+++ b/style.css
@@ -1073,6 +1073,22 @@ button:focus {
   gap: 2px;
   font-size: 0.85rem;
 }
+.quick-filter {
+  background: var(--color-chip-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 0.25rem 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.quick-filter.active {
+  background: var(--color-primary);
+  color: var(--color-surface);
+  border-color: var(--color-primary);
+}
 .filter-chip button {
   border: none;
   background: transparent;


### PR DESCRIPTION
## Summary
- add quick filter buttons in toolbar
- style quick filter chips similar to filters
- implement quick filter logic in JS
- add alert icon

## Testing
- `npm test` *(fails: cannot find module 'jest')*
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68654ef8787883248b72b8789abcd4d1