### PR TITLE
Expose search field by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,18 +34,16 @@
         My Plant Tracker
         <button id="show-add-form" class="bg-primary text-white rounded-md px-4 py-2 ml-auto"></button>
         <button id="export-all" class="bg-primary text-white rounded-md px-4 py-2 ml-2"></button>
-        <button id="toggle-search" class="bg-primary text-white rounded-md px-4 py-2 ml-2">Search</button>
     </h1>
     <div id="summary" class="p-4 bg-card rounded-lg mb-4">
         <!-- counts will go here -->
     </div>
 
-    <div id="search-container" class="mb-4 hidden flex items-center gap-2">
+    <div id="search-container" class="mb-4 flex items-center gap-2">
         <label for="search-input" class="sr-only">Search Plants</label>
         <div class="relative flex-grow">
             <input type="text" id="search-input" placeholder="Search by name or species" class="w-full p-2 border rounded-md" />
         </div>
-        <button id="close-search" type="button" class="bg-gray-200 rounded-md px-3 py-2"></button>
     </div>
 
 
@@ -152,7 +150,7 @@
         </details>
 
         <div class="flex gap-2 justify-end mt-4 sticky bottom-0 bg-card p-4">
-            <button type="button" id="cancel-edit" class="bg-gray-200 rounded-md px-4 py-2 hidden inline-flex items-center gap-2">Cancel</button>
+            <button type="button" id="cancel-edit" class="bg-gray-200 rounded-md px-4 py-2 inline-flex items-center gap-2">Cancel</button>
             <button type="submit" id="submit-btn" class="bg-primary text-white rounded-md px-4 py-2 inline-flex items-center gap-2">Add Plant</button>
         </div>
     </form>

--- a/script.js
+++ b/script.js
@@ -1851,9 +1851,7 @@ async function init(){
   const form = document.getElementById('plant-form');
   const cancelBtn = document.getElementById('cancel-edit');
   const undoBtn = document.getElementById('undo-btn');
-  const toggleSearch = document.getElementById('toggle-search');
   const searchContainer = document.getElementById('search-container');
-  const closeSearch = document.getElementById('close-search');
   const submitBtn = form ? form.querySelector('button[type="submit"]') : null;
   const roomFilter = document.getElementById('room-filter');
   const archivedLink = document.getElementById('archived-link');
@@ -1958,30 +1956,6 @@ async function init(){
       quickFilterWrap.appendChild(btn);
     });
   }
-  if (toggleSearch) {
-    toggleSearch.innerHTML = ICONS.search + '<span class="visually-hidden">Search</span>';
-    toggleSearch.addEventListener('click', () => {
-      if (form) {
-        form.style.display = 'none';
-        if (showBtn) showBtn.style.display = 'inline-block';
-        const cancel = document.getElementById('cancel-edit');
-        if (cancel) cancel.style.display = 'none';
-      }
-      if (searchContainer) searchContainer.classList.remove('hidden');
-      toggleSearch.style.display = 'none';
-      const input = document.getElementById('search-input');
-      if (input) input.focus();
-    });
-  }
-  if (closeSearch) {
-    closeSearch.innerHTML = ICONS.cancel + '<span class="visually-hidden">Close Search</span>';
-    closeSearch.addEventListener('click', () => {
-      if (searchContainer) searchContainer.classList.add('hidden');
-      toggleSearch.style.display = 'inline-block';
-      document.getElementById('search-input').value = '';
-      loadPlants();
-    });
-  }
   if (submitBtn) {
     submitBtn.innerHTML = ICONS.plus + ' Add Plant';
   }
@@ -1993,10 +1967,6 @@ async function init(){
   }
   if (showBtn && form) {
     showBtn.addEventListener('click', () => {
-      if (searchContainer) {
-        searchContainer.classList.add('hidden');
-        toggleSearch.style.display = 'inline-block';
-      }
       form.style.display = 'block';
       showBtn.style.display = 'none';
       const cancel = document.getElementById('cancel-edit');


### PR DESCRIPTION
## Summary
- remove toggle/close search buttons and show search input at page load
- clean up JavaScript search toggle logic

## Testing
- `npm test`
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68655762fc88832487385639a48d2ea6