### PR TITLE
Integrate mobile bottom bar with latest main

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,12 +156,12 @@
     </form>
 
     <div id="toolbar" class="my-4 flex flex-wrap items-center gap-4 p-4">
-        <div id="mode-toggle" class="view-toggle-group inline-flex rounded-lg border border-gray-300 overflow-hidden">
+        <div id="mode-toggle" class="mode-toggle hidden sm:inline-flex view-toggle-group rounded-lg border border-gray-300 overflow-hidden">
             <button type="button" data-mode="tasks" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">Tasks</button>
             <button type="button" data-mode="library" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">All Plants</button>
         </div>
         <div id="filter-container" class="overflow-container flex flex-col items-start gap-2 mr-4 relative">
-            <button id="filter-btn" class="bg-gray-200 rounded-md px-4 py-2 inline-flex items-center gap-2"></button>
+            <button id="filter-btn" class="hidden sm:inline-flex bg-gray-200 rounded-md px-4 py-2 items-center gap-2"></button>
             <div id="quick-filters" class="flex flex-wrap gap-2"></div>
             <div id="filter-chips" class="flex flex-wrap gap-2"></div>
             <button id="filter-summary" class="text-sm filter-summary"></button>
@@ -184,7 +184,7 @@
                 <option value="due" selected>Due Date</option>
                 <option value="added">Date Added</option>
             </select>
-            <div id="view-toggle" class="view-toggle-group inline-flex rounded-lg border border-gray-300 overflow-hidden">
+            <div id="view-toggle" class="view-toggle-group rounded-lg border border-gray-300 overflow-hidden">
                 <button type="button" data-view="grid" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
                 <button type="button" data-view="list" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
                 <button type="button" data-view="text" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
@@ -211,6 +211,14 @@
         <button id="next-week" class="bg-primary text-white rounded-md px-4 py-2"></button>
     </div>
     <div id="calendar" class="p-4"></div>
+    <div id="bottom-bar" class="sm:hidden fixed bottom-0 left-0 right-0 flex justify-around items-center bg-card border-t p-2">
+        <div id="mode-toggle-mobile" class="mode-toggle view-toggle-group rounded-lg border border-gray-300 overflow-hidden">
+            <button type="button" data-mode="tasks" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">Tasks</button>
+            <button type="button" data-mode="library" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">All Plants</button>
+        </div>
+        <button id="filter-btn-mobile" class="bg-gray-200 rounded-md p-2"></button>
+    </div>
+
 
     <script type="module" src="script.js?v=1.0"></script>
 

--- a/script.js
+++ b/script.js
@@ -1858,9 +1858,10 @@ async function init(){
   const sortToggle = document.getElementById('sort-toggle');
   const dueFilterEl = document.getElementById('status-filter');
   const filterBtn = document.getElementById('filter-btn');
+  const filterBtnMobile = document.getElementById('filter-btn-mobile');
   const filterPanel = document.getElementById('filter-panel');
   const quickFilterWrap = document.getElementById('quick-filters');
-  const modeButtons = document.querySelectorAll('#mode-toggle .mode-btn');
+  const modeButtons = document.querySelectorAll('.mode-toggle .mode-btn');
   const viewButtons = document.querySelectorAll('#view-toggle .view-toggle-btn');
   const prevBtn = document.getElementById('prev-week');
   const nextBtn = document.getElementById('next-week');
@@ -1925,6 +1926,12 @@ async function init(){
   if (filterBtn) {
     filterBtn.innerHTML = ICONS.filter + '<span class="visually-hidden">Filters</span>';
     filterBtn.addEventListener('click', () => {
+      if (filterPanel) filterPanel.classList.toggle('show');
+    });
+  }
+  if (filterBtnMobile) {
+    filterBtnMobile.innerHTML = ICONS.filter + '<span class="visually-hidden">Filters</span>';
+    filterBtnMobile.addEventListener('click', () => {
       if (filterPanel) filterPanel.classList.toggle('show');
     });
   }

--- a/style.css
+++ b/style.css
@@ -367,16 +367,31 @@ button:focus {
 }
 
 @media (max-width: 640px) {
-  #view-toggle {
+  #bottom-bar {
     position: fixed;
     bottom: 0;
     left: 0;
     right: 0;
-    justify-content: center;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
     padding: calc(var(--spacing) * 1.5);
     background: var(--color-card);
     border-top: 1px solid var(--color-border);
     z-index: 20;
+  }
+  #view-toggle {
+    position: static;
+    bottom: auto;
+    left: auto;
+    right: auto;
+    padding: 0;
+    background: none;
+    border-top: none;
+    justify-content: center;
+  }
+  body {
+    padding-bottom: calc(var(--spacing) * 7);
   }
 }
 .visually-hidden {


### PR DESCRIPTION
## Summary
- merged latest `main` changes into PR branch
- implemented a sticky bottom bar for mobile with mode toggle and filter button
- adjusted toolbar to hide controls on small screens
- updated JS for mobile filter button and unified mode toggle logic

## Testing
- `npm test`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_68655ce6a8d88324b088b57031a69daa