### PR TITLE
Remove tasks mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,10 +156,7 @@
     </form>
 
     <div id="toolbar" class="my-4 flex flex-wrap items-center gap-4 p-4">
-        <div id="mode-toggle" class="mode-toggle hidden sm:inline-flex view-toggle-group rounded-lg border border-gray-300 overflow-hidden">
-            <button type="button" data-mode="tasks" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">Tasks</button>
-            <button type="button" data-mode="library" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">All Plants</button>
-        </div>
+        
         <div id="filter-container" class="overflow-container flex flex-col items-start gap-2 mr-4 relative">
             <button id="filter-btn" class="hidden sm:inline-flex bg-gray-200 rounded-md px-4 py-2 items-center gap-2"></button>
             <div id="quick-filters" class="flex flex-wrap gap-2"></div>
@@ -212,10 +209,6 @@
     </div>
     <div id="calendar" class="p-4"></div>
     <div id="bottom-bar" class="sm:hidden fixed bottom-0 left-0 right-0 flex justify-around items-center bg-card border-t p-2">
-        <div id="mode-toggle-mobile" class="mode-toggle view-toggle-group rounded-lg border border-gray-300 overflow-hidden">
-            <button type="button" data-mode="tasks" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">Tasks</button>
-            <button type="button" data-mode="library" class="mode-btn view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10">All Plants</button>
-        </div>
         <button id="filter-btn-mobile" class="bg-gray-200 rounded-md p-2"></button>
     </div>
 


### PR DESCRIPTION
## Summary
- simplify UI by removing 'tasks' toggle
- default filter state now shows all plants
- clean up related script logic

## Testing
- `npm test` *(fails: Cannot find module '/workspace/plant-tracker/node_modules/.bin/jest')*
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68656100684c8324944e21493fcf599d