### PR TITLE
Refactor toolbar layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,44 +150,50 @@
         </div>
     </form>
 
-    <div id="toolbar" class="my-4 flex flex-wrap items-center gap-4 p-4">
-        <div id="search-container" class="flex items-center gap-2">
+    <div id="toolbar" class="toolbar my-4 p-4">
+        <div class="toolbar__group toolbar__group--search" id="search-container">
             <label for="search-input" class="sr-only">Search Plants</label>
-            <div class="relative">
+            <div class="relative w-full">
                 <input type="text" id="search-input" placeholder="Search by name or species" class="w-full p-2 border rounded-md" />
             </div>
         </div>
 
-        <button id="status-chip" type="button" class="quick-filter">Status: Needs Care \u25BC</button>
-        <div id="quick-filters" class="flex flex-wrap gap-2"></div>
-
-        <div id="sort-chips" class="flex gap-2"></div>
-        <select id="sort-toggle" class="hidden">
-            <option value="name">Name (A-Z)</option>
-            <option value="name-desc">Name (Z-A)</option>
-            <option value="due" selected>Due Date</option>
-            <option value="added">Date Added</option>
-        </select>
-
-        <div id="filter-container" class="overflow-container flex flex-wrap items-center gap-2 relative">
-            <button id="filter-btn" class="hidden sm:inline-flex bg-gray-200 rounded-md px-4 py-2 items-center gap-2"></button>
-            <div id="filter-panel" class="overflow-menu">
-                <select id="room-filter" class="border rounded-md">
-                    <option value="all" selected>All Rooms</option>
-                </select>
-                <select id="status-filter" class="border rounded-md hidden">
-                    <option value="all">Status: All</option>
-                    <option value="water">Watering</option>
-                    <option value="fert">Fertilizing</option>
-                    <option value="any" selected>Needs Care</option>
-                </select>
-            </div>
+        <div class="toolbar__group toolbar__group--filters">
+            <button id="status-chip" type="button" class="quick-filter filled">Status: Needs Care \u25BC</button>
+            <div id="quick-filters" class="flex flex-wrap gap-2"></div>
         </div>
 
-        <div id="view-toggle" class="view-toggle-group rounded-lg border border-gray-300 overflow-hidden ml-auto">
-            <button type="button" data-view="grid" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
-            <button type="button" data-view="list" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
-            <button type="button" data-view="text" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
+        <div class="toolbar__group toolbar__group--sort">
+            <div id="sort-chips" class="flex gap-2"></div>
+            <select id="sort-toggle" class="hidden">
+                <option value="name">Name (A-Z)</option>
+                <option value="name-desc">Name (Z-A)</option>
+                <option value="due" selected>Due Date</option>
+                <option value="added">Date Added</option>
+            </select>
+        </div>
+
+        <div class="toolbar__group toolbar__group--actions">
+            <div id="filter-container" class="overflow-container relative flex items-center gap-2">
+                <button id="filter-btn" class="hidden sm:inline-flex bg-gray-200 rounded-md p-2 items-center" aria-label="Filters"></button>
+                <span id="filter-summary" class="filter-summary"></span>
+                <div id="filter-panel" class="overflow-menu">
+                    <select id="room-filter" class="border rounded-md">
+                        <option value="all" selected>All Rooms</option>
+                    </select>
+                    <select id="status-filter" class="border rounded-md hidden">
+                        <option value="all">Status: All</option>
+                        <option value="water">Watering</option>
+                        <option value="fert">Fertilizing</option>
+                        <option value="any" selected>Needs Care</option>
+                    </select>
+                </div>
+            </div>
+            <div id="view-toggle" class="view-toggle-group rounded-lg border border-gray-300 overflow-hidden">
+                <button type="button" data-view="grid" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
+                <button type="button" data-view="list" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
+                <button type="button" data-view="text" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"></button>
+            </div>
         </div>
     </div>
     <div id="rainfall-info" class="p-4 bg-card rounded-lg mb-4 hidden"></div>

--- a/script.js
+++ b/script.js
@@ -525,7 +525,11 @@ function updateFilterChips() {
 
   const filterBtn = document.getElementById('filter-btn');
   if (filterBtn) {
-    filterBtn.innerHTML = `${ICONS.filter} ${summaryText}`;
+    filterBtn.innerHTML = ICONS.filter;
+  }
+  const summaryEl = document.getElementById('filter-summary');
+  if (summaryEl) {
+    summaryEl.textContent = summaryText;
   }
 }
 
@@ -1815,6 +1819,7 @@ async function init(){
   const statusChip = document.getElementById('status-chip');
   const sortChipsWrap = document.getElementById('sort-chips');
   const filterBtn = document.getElementById('filter-btn');
+  const filterSummary = document.getElementById('filter-summary');
   const filterBtnMobile = document.getElementById('filter-btn-mobile');
   const filterPanel = document.getElementById('filter-panel');
   const quickFilterWrap = document.getElementById('quick-filters');
@@ -1908,7 +1913,7 @@ async function init(){
     configs.forEach(cfg => {
       const btn = document.createElement('button');
       btn.type = 'button';
-      btn.className = 'quick-filter';
+      btn.className = 'quick-filter outline';
       btn.innerHTML = `${cfg.icon} ${cfg.label}`;
       btn.addEventListener('click', () => {
         if (cfg.key === 'overdue') {
@@ -1939,7 +1944,7 @@ async function init(){
     sortConfigs.forEach(cfg => {
       const btn = document.createElement('button');
       btn.type = 'button';
-      btn.className = 'quick-filter sort-chip';
+      btn.className = 'quick-filter outline sort-chip';
       btn.dataset.value = cfg.value;
       btn.textContent = cfg.label;
       btn.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -1032,8 +1032,30 @@ button:focus {
   gap: calc(var(--spacing) * 2);
 }
 
-#filter-container {
+.toolbar__group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: calc(var(--spacing));
+}
+
+.toolbar__group:not(:last-child) {
   margin-right: calc(var(--spacing) * 2);
+}
+
+.toolbar__group--actions {
+  margin-left: auto;
+}
+
+.filter-summary {
+  background: var(--color-chip-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.85rem;
+}
+
+#filter-container {
   position: relative;
 }
 
@@ -1093,6 +1115,12 @@ button:focus {
   font-size: 0.85rem;
   cursor: pointer;
 }
+.quick-filter.outline {
+  background: transparent;
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+.quick-filter.filled,
 .quick-filter.active {
   background: var(--color-primary);
   color: var(--color-surface);
@@ -1467,6 +1495,12 @@ button:focus {
 
 .suggestions li:hover {
   background: var(--color-highlight);
+}
+
+@media (max-width: 640px) {
+  .toolbar__group--search {
+    flex-basis: 100%;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- group toolbar controls and collapse into single row
- show filter summary next to the gear button
- update chips to use outline/filled styles
- tweak responsive layout for search bar

## Testing
- `phpunit`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68657136d0b483248850da57da4aab3d