### PR TITLE
Show auto-calculated water amount

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,7 @@
                 <p class="helper">Enter ounces of water</p>
                 <div class="error" id="water_amount-error"></div>
             </div>
+            <p id="auto-water-display" class="helper hidden">Auto-calculated: <span id="auto-water-oz">0</span> oz</p>
             <div>
                 <label for="watering_frequency" class="block mb-1">Watering Frequency (days) <span class="required-star" aria-hidden="true">*</span></label>
                 <input type="number" name="watering_frequency" id="watering_frequency" class="w-full border rounded-md p-2" min="1" max="365" required />

--- a/script.js
+++ b/script.js
@@ -357,6 +357,7 @@ function updateWaterAmount() {
   const unitSelect = document.getElementById('pot_diameter_unit');
   const typeSelect = document.getElementById('plant_type');
   const waterAmtInput = document.getElementById('water_amount');
+  const autoDisplay = document.getElementById('auto-water-oz');
   if (!diamInput || !waterAmtInput) return;
   const diam = parseFloat(diamInput.value);
   if (isNaN(diam) || weatherTminC === null || weatherTmaxC === null) return;
@@ -374,7 +375,9 @@ function updateWaterAmount() {
   const area = computeArea(diamCm);
   const waterMl = etc * area * 0.1;
   const oz = waterMl / ML_PER_US_FL_OUNCE;
-  waterAmtInput.value = oz.toFixed(1);
+  const ozStr = oz.toFixed(1);
+  waterAmtInput.value = ozStr;
+  if (autoDisplay) autoDisplay.textContent = ozStr;
   waterAmtInput.dispatchEvent(new Event('input', { bubbles: true }));
   if (editingPlantId) {
     const body = new URLSearchParams({
@@ -1103,18 +1106,26 @@ function populateForm(plant) {
       form.water_amount.value = oz.toFixed(1).replace(/\.0$/, '');
       const oc = document.getElementById('override_water');
       const wg = document.getElementById('water-amount-group');
+      const ad = document.getElementById('auto-water-display');
+      const av = document.getElementById('auto-water-oz');
       if (oc && wg) {
         oc.checked = true;
         wg.classList.remove('hidden');
+        if (ad) ad.classList.add('hidden');
       }
+      if (av) av.textContent = oz.toFixed(1).replace(/\.0$/, '');
     } else {
       form.water_amount.value = '';
       const oc = document.getElementById('override_water');
       const wg = document.getElementById('water-amount-group');
+      const ad = document.getElementById('auto-water-display');
+      const av = document.getElementById('auto-water-oz');
       if (oc && wg) {
         oc.checked = false;
         wg.classList.add('hidden');
+        if (ad) ad.classList.remove('hidden');
       }
+      if (av) av.textContent = '';
     }
   }
   form.fertilizing_frequency.value = plant.fertilizing_frequency;
@@ -1144,10 +1155,14 @@ function resetForm() {
   if (form.water_amount) form.water_amount.value = '';
   const oc = document.getElementById('override_water');
   const wg = document.getElementById('water-amount-group');
+  const ad = document.getElementById('auto-water-display');
+  const av = document.getElementById('auto-water-oz');
   if (oc && wg) {
     oc.checked = false;
     wg.classList.add('hidden');
   }
+  if (ad) ad.classList.remove('hidden');
+  if (av) av.textContent = '';
   const taxInfo = document.getElementById('taxonomy-info');
   if (taxInfo) taxInfo.innerHTML = '';
   const thumbInput = document.getElementById('thumbnail_url');
@@ -1837,6 +1852,7 @@ async function init(){
   const plantTypeSelect = document.getElementById('plant_type');
   const overrideCheck = document.getElementById('override_water');
   const waterGroup = document.getElementById('water-amount-group');
+  const autoWaterDisplay = document.getElementById('auto-water-display');
   const roomInput = document.getElementById('room');
   const nameInput = document.getElementById('name');
   const speciesInput = document.getElementById('species');
@@ -2068,8 +2084,10 @@ async function init(){
   });
   if (overrideCheck && waterGroup) {
     overrideCheck.addEventListener('change', () => {
-      waterGroup.classList.toggle('hidden', !overrideCheck.checked);
-      if (!overrideCheck.checked && waterAmtInput) {
+      const checked = overrideCheck.checked;
+      waterGroup.classList.toggle('hidden', !checked);
+      if (autoWaterDisplay) autoWaterDisplay.classList.toggle('hidden', checked);
+      if (!checked && waterAmtInput) {
         waterAmtInput.value = '';
       }
     });


### PR DESCRIPTION
## Summary
- display auto-calculated water amount when override is off
- update JS to keep the new value in sync and hide/show it when toggling

## Testing
- `npm test` *(fails: Cannot find module 'jest')*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686573502ae08324a93c95a813a3b958