### PR TITLE
Use DOM to build taxonomy gallery

### DIFF
--- a/script.js
+++ b/script.js
@@ -290,10 +290,17 @@ async function showTaxonomyInfo(name) {
 
     let img = photos[0] || '';
     if (photos.length) {
-      const imgsHtml = photos.slice(0, 10).map((url, idx) =>
-        `<img src="${url}" alt="${taxon.name || name}" loading="lazy"${idx === 0 ? ' class="selected"' : ''}>`
-      ).join('');
-      parts.push(`<div class="specimen-gallery">${imgsHtml}</div>`);
+      const galleryDiv = document.createElement('div');
+      galleryDiv.className = 'specimen-gallery';
+      photos.slice(0, 10).forEach((url, idx) => {
+        const imgEl = document.createElement('img');
+        imgEl.src = url;
+        imgEl.alt = taxon.name || name;
+        imgEl.loading = 'lazy';
+        if (idx === 0) imgEl.classList.add('selected');
+        galleryDiv.appendChild(imgEl);
+      });
+      parts.push(galleryDiv.outerHTML);
       if (imageUrlInput) imageUrlInput.value = img;
       if (previewImg && img) {
         previewImg.src = img;


### PR DESCRIPTION
## Summary
- create `<img>` elements with DOM API in `showTaxonomyInfo`
- set attributes via properties to avoid raw HTML

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68659773d2f0832484f7dbd52da5565b