### PR TITLE
Add uploaded photo size limit

### DIFF
--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -79,6 +79,16 @@ if ($errors) {
 
 // Handle uploaded photo
 if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
+    $maxFileSize = 5 * 1024 * 1024; // 5MB
+    if ($_FILES['photo']['size'] > $maxFileSize) {
+        @http_response_code(400);
+        echo json_encode(['error' => 'Photo exceeds 5MB size limit']);
+        if (!getenv('TESTING')) {
+            exit;
+        }
+        return;
+    }
+
     $uploadDir = __DIR__ . '/../uploads/';
     if (!is_dir($uploadDir)) {
         mkdir($uploadDir, 0755, true);

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -97,6 +97,16 @@ if ($errors) {
 
 // Handle uploaded photo
 if (isset($_FILES['photo']) && $_FILES['photo']['error'] === UPLOAD_ERR_OK) {
+    $maxFileSize = 5 * 1024 * 1024; // 5MB
+    if ($_FILES['photo']['size'] > $maxFileSize) {
+        @http_response_code(400);
+        echo json_encode(['error' => 'Photo exceeds 5MB size limit']);
+        if (!getenv('TESTING')) {
+            exit;
+        }
+        return;
+    }
+
     $uploadDir = __DIR__ . '/../uploads/';
     if (!is_dir($uploadDir)) {
         mkdir($uploadDir, 0755, true);


### PR DESCRIPTION
## Summary
- enforce a 5MB size limit for uploaded photos in add/update endpoints
- return an error when file is larger than the limit

## Testing
- `phpunit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686598b7e5ec832497a9036b167fdcaa