### PR TITLE
Remove obsolete back link from analytics page

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,7 @@ Use the main interface at `index.html` to add plants, mark them as watered or fe
 In list or text view you can swipe right on a plant card to complete all due tasks (watering and fertilizing) at once. The card slides with your finger and smoothly snaps back if you don't pass the threshold.
 
 You can also export your current plant list as JSON or CSV using the download buttons at the top of the page.
-The new **Analytics** link opens a page with charts of historical ET₀ and water use.
-It links back to the main interface using the same `#plant-{id}` fragment so you return to the plant you were analyzing.
+The **Analytics** link now opens the analytics page in a new tab with charts of historical ET₀ and water use.
 
 The plant form offers live suggestions for scientific names as you type a common
 plant name. Selecting a scientific name fills the field and loads a thumbnail

--- a/analytics.html
+++ b/analytics.html
@@ -34,7 +34,6 @@
   <div class="max-w-3xl mx-auto bg-card rounded-lg shadow p-4 my-4">
     <h1 class="app-title text font-bold mb-4">
       Plant Analytics
-      <a id="backLink" href="index.html" class="bg-primary text-white rounded-md px-4 py-2 ml-auto">Back to Plant</a>
     </h1>
 
     <h2 class="font-semibold mb-2">Filters</h2>

--- a/analytics.js
+++ b/analytics.js
@@ -18,10 +18,6 @@ function setDefaultDatesToCurrentWeek() {
   if (endInput && !endInput.value) endInput.value = toISO(end);
 }
 
-const backLink = document.getElementById('backLink');
-if (backLink && initialPlantId) {
-  backLink.href = `index.html#plant-${initialPlantId}`;
-}
 setDefaultDatesToCurrentWeek();
 
 function drawChart(data) {

--- a/script.js
+++ b/script.js
@@ -1628,6 +1628,8 @@ async function loadPlants() {
     analyticsLink.innerHTML = ICONS.analytics + '<span class="visually-hidden">Analytics</span>';
     analyticsLink.title = 'Analytics';
     analyticsLink.href = `analytics.html?plant_id=${plant.id}`;
+    analyticsLink.target = '_blank';
+    analyticsLink.rel = 'noopener';
     actionsDiv.appendChild(analyticsLink);
 
     const fileInput = document.createElement('input');


### PR DESCRIPTION
## Summary
- drop the "Back to Plant" link from analytics page
- remove code that set the back link URL
- open Analytics in a new tab from each plant card
- update README documentation

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68659aa343f883249178ba8d69242bf3