### PR TITLE
Add floating action button styling on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -1517,3 +1517,13 @@ button:focus {
 
 
 
+
+@media (max-width: 640px) {
+  #show-add-form {
+    position: fixed;
+    bottom: calc(var(--spacing) * 3);
+    right: calc(var(--spacing) * 3);
+    z-index: 900;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+  }
+}


### PR DESCRIPTION
## Summary
- float the `show-add-form` button at bottom-right on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865afbae3108324a5626a87ecfdd764