### PR TITLE
Display count on Needs Care filter

### DIFF
--- a/script.js
+++ b/script.js
@@ -1312,6 +1312,7 @@ async function loadPlants() {
   const startOfDayAfterTomorrow = addDays(startOfTomorrow,1);
 
   list.innerHTML = '';
+  let needsCareCount = 0;
   const filtered = plants.filter(plant => {
     if (selectedRoom !== 'all' && plant.room !== selectedRoom) return false;
     const haystack = (plant.name + ' ' + plant.species).toLowerCase();
@@ -1319,6 +1320,7 @@ async function loadPlants() {
 
     const waterDue = needsWatering(plant, today);
     const fertDue = needsFertilizing(plant, today);
+    if (waterDue || fertDue) needsCareCount++;
     if (statusFilter === 'water' && !waterDue) return false;
     if (statusFilter === 'fert' && !fertDue) return false;
     if (statusFilter === 'any' && !(waterDue || fertDue)) return false;
@@ -1383,6 +1385,12 @@ async function loadPlants() {
   summaryEl.appendChild(row1);
   summaryEl.appendChild(row2);
   summaryEl.classList.add('show');
+
+  const statusChip = document.getElementById('status-chip');
+  if (statusChip) {
+    statusChip.textContent = 'Needs Care' +
+      (statusChip.classList.contains('active') ? ` (${needsCareCount})` : '');
+  }
 
   const sortBy = document.getElementById('sort-toggle').value || 'due';
   filtered.sort((a, b) => {


### PR DESCRIPTION
## Summary
- compute total plants needing care when loading plants
- append the total to the "Needs Care" filter chip while active

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6865af66aa4c8324991967b862443e01