### PR TITLE
Improve toolbar styling and header actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,8 @@
 <body class="bg-bg text-text min-h-screen">
     <h1 class="app-title text font-bold px-4 py-0">
         My Plant Tracker
-        <button id="show-add-form" class="bg-primary text-white rounded-md px-4 py-2 ml-auto"></button>
-        <button id="export-all" class="bg-primary text-white rounded-md px-4 py-2 ml-2"></button>
+        <button id="show-add-form" class="ml-auto"></button>
+        <button id="export-all" class="ml-2"></button>
     </h1>
     <div id="summary" class="p-4 bg-card rounded-lg mb-4">
         <!-- counts will go here -->
@@ -136,7 +136,7 @@
         </div>
     </form>
 
-    <div class="toolbar my-4 p-4">
+    <div class="toolbar my-4 p-4 bg-card rounded-lg shadow">
         <label for="search-input" class="sr-only">Search Plants</label>
         <input type="text" id="search-input" class="toolbar__search" placeholder="Search by name or species" />
 

--- a/style.css
+++ b/style.css
@@ -93,6 +93,38 @@ h1 {
   color: var(--color-primary);
 }
 
+/* header action buttons */
+#show-add-form,
+#export-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  font-weight: 600;
+}
+
+#show-add-form {
+  background: var(--color-primary);
+  color: var(--color-surface);
+}
+
+#show-add-form:hover,
+#show-add-form:focus {
+  background: var(--color-plant-hover);
+}
+
+#export-all {
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+#export-all:hover,
+#export-all:focus {
+  background: var(--color-chip-bg);
+}
+
 h2 {
     font-size: clamp(1.375rem, 4vw, 1.5rem);
 }
@@ -1015,12 +1047,19 @@ button:focus {
   flex-wrap: wrap;
   align-items: center;
   gap: calc(var(--spacing) * 2);
+  background: var(--color-card);
+  border-radius: var(--radius);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
 .toolbar__search {
   flex: 1 1 250px;
-  padding: 0.5rem;
-  background: var(--color-card);
+  padding: 0.5rem 0.5rem 0.5rem 2rem;
+  background: var(--color-card) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'/%3E%3C/svg%3E") 0.5rem center no-repeat;
+  background-size: 1rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
 }
@@ -1058,6 +1097,11 @@ button:focus {
   gap: 4px;
   font-size: 0.85rem;
   cursor: pointer;
+}
+
+.chip:hover {
+  background: var(--color-chip-bg);
+  filter: brightness(95%);
 }
 
 .chip.active,


### PR DESCRIPTION
## Summary
- style add plant & export buttons as pills
- make toolbar card-like with sticky position
- add search icon to toolbar input
- lighten chip interaction
- update markup to use new styles

## Testing
- `npm test`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6865b328214883248a998e9551deaae6