### PR TITLE
Add filter tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ water amount input so you can enter your own value. When editing a plant that
 already has a custom amount saved, the box starts checked and your value is
 preserved until you clear it.
 
+### Filtering Plants
+The toolbar includes a **Filters** button on smaller screens. Clicking it reveals
+dropdowns for narrowing the list. You can filter by **room**, show plants that
+need specific **care** (watering or fertilizing), and change the **sort** order.
+Selections apply instantly and the panel hides after you choose an option.
+
 ## Service Worker
 A small service worker caches the key pages and scripts so the app still opens when you're offline. During development you may need to disable the cache or bump the version in `service-worker.js` to pick up changes.
 

--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -1,0 +1,57 @@
+import { jest } from '@jest/globals';
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <div id="plant-grid"></div>
+    <select id="room-filter"><option value="all">All</option><option value="Kitchen">Kitchen</option><option value="Patio">Patio</option></select>
+    <select id="status-filter"><option value="all">All</option><option value="water">Watering</option><option value="any">Needs Care</option></select>
+    <input id="search-input" value="" />
+    <div id="summary"></div>
+    <select id="sort-toggle"></select>
+  `;
+}
+
+beforeEach(() => {
+  jest.resetModules();
+  Object.defineProperty(document, 'readyState', { configurable: true, get: () => 'loading' });
+});
+
+test('loadPlants filters by room and search query', async () => {
+  setupDOM();
+  const plants = [
+    { id: 1, name: 'Aloe', species: 'Aloe vera', room: 'Kitchen', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' },
+    { id: 2, name: 'Basil', species: 'Ocimum', room: 'Patio', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' }
+  ];
+  global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve(plants) });
+  let mod;
+  await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
+
+  document.getElementById('search-input').value = 'aloe';
+  document.getElementById('room-filter').value = 'Kitchen';
+  await mod.loadPlants();
+
+  const cards = document.querySelectorAll('.plant-card-wrapper');
+  expect(cards.length).toBe(1);
+  expect(cards[0].id).toBe('plant-1');
+});
+
+test('loadPlants respects status filter', async () => {
+  setupDOM();
+  jest.useFakeTimers().setSystemTime(new Date('2023-01-10'));
+  const plants = [
+    { id: 1, name: 'A', species: 'sp', room: 'Kitchen', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' },
+    { id: 2, name: 'B', species: 'sp', room: 'Kitchen', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-08', last_fertilized: null, created_at: '2023-01-01' }
+  ];
+  global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve(plants) });
+  let mod;
+  await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
+
+  document.getElementById('status-filter').value = 'water';
+  await mod.loadPlants();
+
+  jest.useRealTimers();
+
+  const cards = document.querySelectorAll('.plant-card-wrapper');
+  expect(cards.length).toBe(1);
+  expect(cards[0].id).toBe('plant-1');
+});


### PR DESCRIPTION
## Summary
- cover client-side filtering with new tests
- document the Filters menu usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865ba332f94832491af5805da8ee8ac