### PR TITLE
Fix filter panel closing on extra filters

### DIFF
--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -8,6 +8,7 @@ function setupDOM() {
     <input id="search-input" value="" />
     <div id="summary"></div>
     <select id="sort-toggle"></select>
+    <div id="location-filters"><label><input type="checkbox" value="outside" /></label><label><input type="checkbox" value="inside" checked /></label></div>
   `;
 }
 
@@ -50,6 +51,27 @@ test('loadPlants respects status filter', async () => {
   await mod.loadPlants();
 
   jest.useRealTimers();
+
+  const cards = document.querySelectorAll('.plant-card-wrapper');
+  expect(cards.length).toBe(1);
+  expect(cards[0].id).toBe('plant-1');
+});
+
+test('loadPlants filters by location checkbox', async () => {
+  setupDOM();
+  const plants = [
+    { id: 1, name: 'A', species: 'sp', room: 'Garden', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' },
+    { id: 2, name: 'B', species: 'sp', room: 'Kitchen', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' }
+  ];
+  global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve(plants) });
+  let mod;
+  await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
+
+  const outsideCheck = document.querySelector('#location-filters input[value="outside"]');
+  outsideCheck.checked = true;
+  const insideCheck = document.querySelector('#location-filters input[value="inside"]');
+  insideCheck.checked = false;
+  await mod.loadPlants();
 
   const cards = document.querySelectorAll('.plant-card-wrapper');
   expect(cards.length).toBe(1);

--- a/script.js
+++ b/script.js
@@ -2000,7 +2000,7 @@ async function init(){
     filterBtn.addEventListener('click', () => {
       if (filterPanel) filterPanel.classList.toggle('show');
     });
-    updateFilterChips();
+  }
 
   if (filterToggle && filterPanel) {
     filterToggle.innerHTML = ICONS.filter + ' Filters';
@@ -2012,7 +2012,7 @@ async function init(){
       if (!filterPanel.contains(e.target) && e.target !== filterToggle) {
         filterPanel.classList.remove('show');
       }
-
+    });
   }
   if (statusChip && dueFilterEl) {
     if (dueFilterEl.value === 'any') statusChip.classList.add('active');
@@ -2308,7 +2308,6 @@ async function init(){
       saveFilterPrefs();
       loadPlants();
       updateFilterChips();
-      if (filterPanel) filterPanel.classList.remove('show');
     });
   });
 


### PR DESCRIPTION
## Summary
- keep filter panel open when toggling extra filter checkboxes
- clean up redundant filter button logic
- test multi-select location filters

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865e6c54b9c8324ae30fa5ad7fcdc60