### PR TITLE
Align form colors with site palette

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="style.css">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="manifest" href="manifest.json">
-  <meta name="theme-color" content="#8d67d6">
+  <meta name="theme-color" content="#4caf50">
   <link rel="stylesheet" href="css/tailwind.css">
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
@@ -25,7 +25,7 @@
       <select id="plantSelect" class="border rounded-md p-2"></select>
       <input type="date" id="startDate" class="border rounded-md p-2">
       <input type="date" id="endDate" class="border rounded-md p-2">
-      <button id="refresh" class="bg-primary text-white rounded-md px-3 py-2">Show</button>
+      <button id="refresh" class="btn btn-primary px-3">Show</button>
     </div>
 
     <h2 class="font-semibold mb-2">ET₀ Chart</h2>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="style.css">
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="manifest" href="manifest.json">
-    <meta name="theme-color" content="#8d67d6">
+    <meta name="theme-color" content="#4caf50">
     <link rel="stylesheet" href="css/tailwind.css">
 </head>
 <body class="bg-bg text-text min-h-screen">
@@ -131,8 +131,8 @@
         </details>
 
         <div class="flex gap-2 justify-end mt-4 sticky bottom-0 bg-card p-4">
-            <button type="button" id="cancel-edit" class="bg-gray-200 rounded-md px-4 py-2 inline-flex items-center gap-2">Cancel</button>
-            <button type="submit" id="submit-btn" class="bg-primary text-white rounded-md px-4 py-2 inline-flex items-center gap-2">Add Plant</button>
+            <button type="button" id="cancel-edit" class="btn btn-secondary">Cancel</button>
+            <button type="submit" id="submit-btn" class="btn btn-primary">Add Plant</button>
         </div>
     </form>
 
@@ -210,8 +210,8 @@
 
     <h2 id="calendar-heading" class="text-xl font-semibold p-4">Upcoming Tasks</h2>
     <div id="calendar-nav" class="flex justify-end gap-2 px-4 pb-2">
-        <button id="prev-week" class="bg-primary text-white rounded-md px-4 py-2"><span class="visually-hidden">Previous Week</span></button>
-        <button id="next-week" class="bg-primary text-white rounded-md px-4 py-2"><span class="visually-hidden">Next Week</span></button>
+        <button id="prev-week" class="btn btn-primary"><span class="visually-hidden">Previous Week</span></button>
+        <button id="next-week" class="btn btn-primary"><span class="visually-hidden">Next Week</span></button>
     </div>
     <div id="calendar" class="p-4"></div>
 

--- a/style.css
+++ b/style.css
@@ -1,8 +1,8 @@
 :root {
 
---color-primary: #4caf50; 
+--color-primary: #4caf50;
 
---color-accent: #8bc34a; 
+--color-accent: #8bc34a;
 
 --color-bg: #ffffff;
  --color-card: #ffffff;
@@ -10,7 +10,7 @@
 
  --color-border: #a5d6a7;
 
---color-text: #2e3a29; 
+--color-text: #2e3a29;
 
   --radius: 5px;
   --spacing: 8px;
@@ -57,6 +57,51 @@
 .bg-primary {
   background-color: var(--color-primary);
   color: var(--color-surface);
+}
+
+/* reusable button styles */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.1s;
+  border: 1px solid transparent;
+}
+
+.btn:hover,
+.btn:focus {
+  filter: brightness(95%);
+  transform: translateY(-2px);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: var(--color-surface);
+  border-color: var(--color-primary);
+}
+
+.btn-primary:hover,
+.btn-primary:focus {
+  background: var(--color-plant-hover);
+}
+
+.btn-secondary {
+  background: var(--color-surface);
+  color: var(--color-text);
+  border-color: var(--color-border);
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus {
+  background: var(--color-chip-bg);
 }
 
 html {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,8 +8,8 @@ module.exports = {
       colors: {
         bg: 'var(--color-bg)',
         card: 'var(--color-card)',
-        primary: '#8d67d6',
-        accent: '#ffa5d8',
+        primary: '#4caf50',
+        accent: '#8bc34a',
         text: 'var(--color-text)'
       }
     }


### PR DESCRIPTION
## Summary
- use green color palette on form elements
- add generic button styles for form controls
- apply new button classes across pages

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865eef04a988324a884c61aa1f15e01