### PR TITLE
Remove unused filters

### DIFF
--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -8,7 +8,8 @@ function setupDOM() {
     <input id="search-input" value="" />
     <div id="summary"></div>
     <select id="sort-toggle"></select>
-    <div id="location-filters"><label><input type="checkbox" value="outside" /></label><label><input type="checkbox" value="inside" checked /></label></div>
+    <div id="type-filters"><label><input type="checkbox" value="succulent" /></label></div>
+    <div id="care-filters"></div>
   `;
 }
 
@@ -57,20 +58,18 @@ test('loadPlants respects status filter', async () => {
   expect(cards[0].id).toBe('plant-1');
 });
 
-test('loadPlants filters by location checkbox', async () => {
+test('loadPlants filters by plant type checkbox', async () => {
   setupDOM();
   const plants = [
-    { id: 1, name: 'A', species: 'sp', room: 'Garden', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' },
-    { id: 2, name: 'B', species: 'sp', room: 'Kitchen', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' }
+    { id: 1, name: 'A', species: 'sp', room: 'Garden', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01', plant_type: 'succulent' },
+    { id: 2, name: 'B', species: 'sp', room: 'Kitchen', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01', plant_type: 'herb' }
   ];
   global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve(plants) });
   let mod;
   await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
 
-  const outsideCheck = document.querySelector('#location-filters input[value="outside"]');
-  outsideCheck.checked = true;
-  const insideCheck = document.querySelector('#location-filters input[value="inside"]');
-  insideCheck.checked = false;
+  const typeCheck = document.querySelector('#type-filters input[value="succulent"]');
+  typeCheck.checked = true;
   await mod.loadPlants();
 
   const cards = document.querySelectorAll('.plant-card-wrapper');

--- a/index.html
+++ b/index.html
@@ -160,12 +160,6 @@
                     <option value="fert">Fertilizing</option>
                     <option value="any" selected>Needs Care</option>
                 </select>
-                <div id="location-filters" class="flex flex-wrap gap-2 text-sm">
-                    <label class="quick-filter"><input type="checkbox" value="inside">Inside</label>
-                    <label class="quick-filter"><input type="checkbox" value="outside">Outside</label>
-                    <label class="quick-filter"><input type="checkbox" value="office">Office</label>
-                    <label class="quick-filter"><input type="checkbox" value="library">Library</label>
-                </div>
                 <div id="type-filters" class="flex flex-wrap gap-2 text-sm">
                     <label class="quick-filter"><input type="checkbox" value="succulent">Succulent</label>
                     <label class="quick-filter"><input type="checkbox" value="herb">Herb</label>
@@ -179,12 +173,7 @@
                     <label class="quick-filter"><input type="checkbox" value="due-today">Due Today</label>
                     <label class="quick-filter"><input type="checkbox" value="fertilizing-soon">Fertilizing Soon</label>
                 </div>
-                <div id="pot-size-filters" class="flex flex-wrap gap-2 text-sm">
-                    <label class="quick-filter"><input type="checkbox" value="small">Small Pot</label>
-                    <label class="quick-filter"><input type="checkbox" value="medium">Medium Pot</label>
-                    <label class="quick-filter"><input type="checkbox" value="large">Large Pot</label>
-                </div>
-                <label class="quick-filter text-sm"><input type="checkbox" id="recently-added">Recently Added</label>
+                
             </div>
         </div>
 

--- a/script.js
+++ b/script.js
@@ -474,20 +474,12 @@ function saveFilterPrefs() {
   if (rf) localStorage.setItem('roomFilter', rf.value);
   if (sf) localStorage.setItem('sortPref', sf.value);
   if (df) localStorage.setItem('statusFilter', df.value);
-  const locations = Array.from(document.querySelectorAll('#location-filters input:checked'))
-    .map(cb => cb.value);
   const types = Array.from(document.querySelectorAll('#type-filters input:checked'))
     .map(cb => cb.value);
   const care = Array.from(document.querySelectorAll('#care-filters input:checked'))
     .map(cb => cb.value);
-  const pot = Array.from(document.querySelectorAll('#pot-size-filters input:checked'))
-    .map(cb => cb.value);
-  const recent = document.getElementById('recently-added')?.checked;
-  localStorage.setItem('locationFilters', JSON.stringify(locations));
   localStorage.setItem('typeFilters', JSON.stringify(types));
   localStorage.setItem('careFilters', JSON.stringify(care));
-  localStorage.setItem('potFilters', JSON.stringify(pot));
-  localStorage.setItem('recentOnly', recent ? '1' : '0');
 }
 
 function loadFilterPrefs() {
@@ -500,36 +492,22 @@ function loadFilterPrefs() {
   if (rf) rf.value = rVal !== null ? rVal : 'all';
   if (sf) sf.value = sVal !== null ? sVal : 'due';
   if (df) df.value = dVal !== null ? dVal : 'any';
-  const locs = JSON.parse(localStorage.getItem('locationFilters') || '[]');
   const types = JSON.parse(localStorage.getItem('typeFilters') || '[]');
   const care = JSON.parse(localStorage.getItem('careFilters') || '[]');
-  const pots = JSON.parse(localStorage.getItem('potFilters') || '[]');
-  const recent = localStorage.getItem('recentOnly') === '1';
-  document.querySelectorAll('#location-filters input').forEach(cb => {
-    cb.checked = locs.includes(cb.value);
-  });
   document.querySelectorAll('#type-filters input').forEach(cb => {
     cb.checked = types.includes(cb.value);
   });
   document.querySelectorAll('#care-filters input').forEach(cb => {
     cb.checked = care.includes(cb.value);
   });
-  document.querySelectorAll('#pot-size-filters input').forEach(cb => {
-    cb.checked = pots.includes(cb.value);
-  });
-  const recentEl = document.getElementById('recently-added');
-  if (recentEl) recentEl.checked = recent;
 }
 
 function clearFilterPrefs() {
   localStorage.removeItem('roomFilter');
   localStorage.removeItem('sortPref');
   localStorage.removeItem('statusFilter');
-  localStorage.removeItem('locationFilters');
   localStorage.removeItem('typeFilters');
   localStorage.removeItem('careFilters');
-  localStorage.removeItem('potFilters');
-  localStorage.removeItem('recentOnly');
 }
 
 function saveHistoryValue(key, value) {
@@ -1317,11 +1295,9 @@ async function loadPlants() {
   const statusFilter = document.getElementById('status-filter')
     ? document.getElementById('status-filter').value
     : 'all';
-  const locFilters = Array.from(document.querySelectorAll('#location-filters input:checked')).map(cb => cb.value);
   const typeFilters = Array.from(document.querySelectorAll('#type-filters input:checked')).map(cb => cb.value);
   const careFilters = Array.from(document.querySelectorAll('#care-filters input:checked')).map(cb => cb.value);
-  const potFilters = Array.from(document.querySelectorAll('#pot-size-filters input:checked')).map(cb => cb.value);
-  const recentOnly = document.getElementById('recently-added')?.checked;
+
 
   const rainEl = document.getElementById('rainfall-info');
   if (rainEl) {
@@ -1374,14 +1350,7 @@ async function loadPlants() {
     if (statusFilter === 'fert' && !fertDue) return false;
     if (statusFilter === 'any' && !(waterDue || fertDue)) return false;
 
-    let plantLocation = 'inside';
-    if (plant.room) {
-      const r = plant.room.toLowerCase();
-      if (r.includes('outside') || r.includes('garden') || r.includes('yard')) plantLocation = 'outside';
-      else if (r.includes('office')) plantLocation = 'office';
-      else if (r.includes('library')) plantLocation = 'library';
-    }
-    if (locFilters.length && !locFilters.includes(plantLocation)) return false;
+
 
     if (typeFilters.length) {
       let ptype = plant.plant_type || '';
@@ -1389,13 +1358,7 @@ async function loadPlants() {
       if (!typeFilters.includes(ptype)) return false;
     }
 
-    if (potFilters.length) {
-      const amt = parseFloat(plant.water_amount || 0);
-      let cat = 'small';
-      if (amt > 5) cat = 'large';
-      else if (amt > 2) cat = 'medium';
-      if (!potFilters.includes(cat)) return false;
-    }
+
 
     if (careFilters.length) {
       const soonest = getSoonestDueDate(plant);
@@ -1407,10 +1370,7 @@ async function loadPlants() {
       if (!careFilters.some(c => statuses.includes(c))) return false;
     }
 
-    if (recentOnly) {
-      const created = new Date(plant.created_at);
-      if ((today - created) / 86400000 > 30) return false;
-    }
+
     return true;
   });
 
@@ -2304,7 +2264,7 @@ async function init(){
   }
 
   const extraFilterInputs = document.querySelectorAll(
-    '#location-filters input,#type-filters input,#care-filters input,#pot-size-filters input,#recently-added'
+    '#type-filters input,#care-filters input'
   );
   extraFilterInputs.forEach(input => {
     input.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- simplify filter panel by removing location, pot size, and recently added filters
- update filter preference logic to match reduced filters
- remove related code paths in plant loading logic
- test filtering by plant type instead of location

## Testing
- `npm test` *(fails: Cannot find module '.../jest')*

------
https://chatgpt.com/codex/tasks/task_e_6865f356363883249904b8a0a3399b70