### PR TITLE
Remove filter button

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
     <div class="toolbar my-4 p-4 bg-card rounded-lg shadow">
         <label for="search-input" class="sr-only">Search Plants</label>
         <input type="text" id="search-input" class="toolbar__search" placeholder="Search by name or species" />
-        <button id="filter-toggle" type="button" class="chip">Filters</button>
+        <button id="filter-toggle" type="button" class="chip" data-count="0">Filters</button>
 
         <button id="status-chip" type="button" class="chip active">Needs Care</button>
         <select id="sort-toggle" class="hidden">
@@ -149,7 +149,6 @@
             <option value="added">Date Added</option>
         </select>
         <div class="overflow-container relative">
-            <button id="filter-btn" class="filter-btn" data-count="0" aria-label="Filters"><span class="visually-hidden">Filters</span></button>
             <div id="filter-panel" class="overflow-menu">
                 <select id="room-filter" class="border rounded-md">
                     <option value="all" selected>All Rooms</option>

--- a/script.js
+++ b/script.js
@@ -567,7 +567,7 @@ function applyViewMode() {
 
 
 function updateFilterChips() {
-  const filterBtn = document.getElementById('filter-btn');
+  const filterToggle = document.getElementById('filter-toggle');
   const room = document.getElementById('room-filter')?.value || 'all';
   const status = document.getElementById('status-filter')?.value || 'any';
   const sort = document.getElementById('sort-toggle')?.value || 'due';
@@ -579,9 +579,9 @@ function updateFilterChips() {
   if (status !== defaultStatus) activeCount++;
   if (sort !== defaultSort) activeCount++;
 
-  if (filterBtn) {
-    filterBtn.innerHTML = ICONS.filter;
-    filterBtn.setAttribute('data-count', activeCount);
+  if (filterToggle) {
+    filterToggle.innerHTML = ICONS.filter + ' Filters';
+    filterToggle.setAttribute('data-count', activeCount);
   }
   return activeCount;
 }
@@ -1930,7 +1930,6 @@ async function init(){
   const sortToggle = document.getElementById('sort-toggle');
   const dueFilterEl = document.getElementById('status-filter');
   const statusChip = document.getElementById('status-chip');
-  const filterBtn = document.getElementById('filter-btn');
   const filterPanel = document.getElementById('filter-panel');
   const filterToggle = document.getElementById('filter-toggle');
   const viewButtons = document.querySelectorAll('#view-toggle .view-toggle-btn');
@@ -1996,17 +1995,8 @@ async function init(){
     undoBtn.innerHTML = ICONS.undo + ' Undo';
   }
 
-  if (filterBtn) {
-    filterBtn.addEventListener('click', () => {
-      if (filterPanel) filterPanel.classList.toggle('show');
-    });
-
-    updateFilterChips();
-
-  }
 
   if (filterToggle && filterPanel) {
-    filterToggle.innerHTML = ICONS.filter + ' Filters';
     filterToggle.addEventListener('click', (e) => {
       e.stopPropagation();
       filterPanel.classList.toggle('show');

--- a/style.css
+++ b/style.css
@@ -1125,31 +1125,7 @@ button:focus {
   border-color: var(--color-primary);
 }
 
-.filter-btn {
-  position: relative;
-  padding: 0.35rem 0.75rem;
-  font-size: 1rem;
-  background: var(--color-chip-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius);
-}
 
-.filter-btn::after {
-  content: attr(data-count);
-  position: absolute;
-  top: -6px;
-  right: -6px;
-  background: #dd3333;
-  color: white;
-  font-size: 0.65rem;
-  padding: 0 4px;
-  border-radius: 999px;
-  display: none;
-}
-
-.filter-btn[data-count]:not([data-count="0"])::after {
-  display: inline-block;
-}
 
 
 .overflow-menu {


### PR DESCRIPTION
## Summary
- remove the old `filter-btn` button from the toolbar
- drop unused `.filter-btn` styles
- use `#filter-toggle` to show active filter count
- open the filter panel when `#filter-toggle` is clicked

## Testing
- `npm test`
- `phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6865eeb0ee3c83249c0737f902955088