### PR TITLE
Limit toolbar search width

### DIFF
--- a/style.css
+++ b/style.css
@@ -1102,6 +1102,7 @@ button:focus {
 
 .toolbar__search {
   flex: 1 1 250px;
+  max-width: 350px;
   padding: 0.5rem;
   background: var(--color-card);
   border: 1px solid var(--color-border);
@@ -1640,6 +1641,7 @@ button:focus {
 @media (max-width: 640px) {
   .toolbar__search {
     flex-basis: 100%;
+    max-width: none;
   }
 }
 


### PR DESCRIPTION
## Summary
- tweak `.toolbar__search` with `max-width: 350px`
- prevent width restriction on small screens

## Testing
- `phpunit` *(fails: command not found)*
- `npm test --silent` *(fails: cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_e_6865f80c93988324a23d4df25d6a3465