### PR TITLE
Fix view toggle icons missing

### DIFF
--- a/script.js
+++ b/script.js
@@ -2286,7 +2286,8 @@ async function init(){
 
   if (viewButtons.length) {
     viewButtons.forEach(btn => {
-      if (!btn.innerHTML.trim()) {
+      // Inject icons if they haven't been added yet
+      if (!btn.querySelector('svg')) {
         const label = btn.dataset.view.charAt(0).toUpperCase() + btn.dataset.view.slice(1);
         btn.innerHTML = `${ICONS[btn.dataset.view] || ''}<span class="visually-hidden">${label}</span>`;
       }


### PR DESCRIPTION
## Summary
- ensure icons are injected for view-toggle buttons even when they include hidden text

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6865f7440b608324a30fdb6ed5ba2883