### PR TITLE
Add automatic dark mode based on sunset

### DIFF
--- a/api/weather.php
+++ b/api/weather.php
@@ -59,7 +59,9 @@ $result = [
     'temp_max' => $weatherData['main']['temp_max'] ?? null,
     'desc' => $weatherData['weather'][0]['main'] ?? '',
     'icon' => $weatherData['weather'][0]['icon'] ?? '',
-    'rain' => $rain
+    'rain' => $rain,
+    'sunset' => $weatherData['sys']['sunset'] ?? null,
+    'sunrise' => $weatherData['sys']['sunrise'] ?? null
 ];
 http_response_code(200);
 echo json_encode($result);

--- a/style.css
+++ b/style.css
@@ -53,6 +53,14 @@
   --font-size-xl: 1.5rem;      /* 24px extra large text */
 }
 
+body.dark {
+  --color-bg: #1f2937;
+  --color-card: #374151;
+  --color-surface: #1f2937;
+  --color-border: #4b5563;
+  --color-text: #f9fafb;
+}
+
 
 .bg-primary {
   background-color: var(--color-primary);


### PR DESCRIPTION
## Summary
- enable dark theme via new CSS variables
- expose sunset/sunrise data in `weather.php`
- toggle dark mode after fetching weather
- periodically check for night/day

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_686606f4bbd88324b614e3282985b383