### PR TITLE
Add filter chips

### DIFF
--- a/__tests__/chip.test.js
+++ b/__tests__/chip.test.js
@@ -1,0 +1,36 @@
+import { jest } from '@jest/globals';
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <button id="filter-toggle"></button>
+    <div id="filter-chips"></div>
+    <span id="filter-summary"></span>
+    <select id="room-filter"><option value="all">All Rooms</option><option value="Kitchen">Kitchen</option></select>
+    <select id="status-filter"><option value="any">Needs Care</option></select>
+    <select id="sort-toggle"><option value="due">Due Date</option><option value="name">Name</option></select>
+    <div id="type-filters"><label>Succulent<input type="checkbox" value="succulent"></label></div>
+  `;
+}
+
+beforeEach(() => {
+  jest.resetModules();
+  Object.defineProperty(document, 'readyState', { configurable: true, get: () => 'loading' });
+});
+
+test('updateFilterChips shows count and chips', async () => {
+  setupDOM();
+  let mod;
+  await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
+  mod.updateFilterChips();
+  expect(document.querySelectorAll('#filter-chips .filter-chip').length).toBe(0);
+  expect(document.getElementById('filter-summary').textContent).toBe('No filters');
+  expect(document.getElementById('filter-toggle').getAttribute('data-count')).toBe('0');
+
+  document.getElementById('room-filter').value = 'Kitchen';
+  document.querySelector('#type-filters input').checked = true;
+  mod.updateFilterChips();
+  const chips = document.querySelectorAll('#filter-chips .filter-chip');
+  expect(chips.length).toBe(2);
+  expect(chips[0].textContent).toContain('Kitchen');
+  expect(document.getElementById('filter-toggle').getAttribute('data-count')).toBe('2');
+});

--- a/index.html
+++ b/index.html
@@ -167,9 +167,12 @@
                     <label class="quick-filter"><input type="checkbox" value="houseplant">Houseplant</label>
                     <label class="quick-filter"><input type="checkbox" value="cacti">Cacti</label>
                 </div>
-                
+
             </div>
         </div>
+
+        <div id="filter-chips" class="toolbar__chips"></div>
+        <span id="filter-summary" class="filter-summary"></span>
 
         <div class="toolbar__view view-toggle-group" id="view-toggle">
             <button type="button" data-view="grid" class="view-toggle-btn px-4 py-2 text-gray-600 hover:bg-gray-100 focus:z-10"><span class="visually-hidden">Grid view</span></button>

--- a/script.js
+++ b/script.js
@@ -556,17 +556,67 @@ function applyViewMode() {
 
 function updateFilterChips() {
   const filterToggle = document.getElementById('filter-toggle');
-  const room = document.getElementById('room-filter')?.value || 'all';
-  const status = document.getElementById('status-filter')?.value || 'any';
-  const sort = document.getElementById('sort-toggle')?.value || 'due';
+  const chipsEl = document.getElementById('filter-chips');
+  const summaryEl = document.getElementById('filter-summary');
+
+  const roomEl = document.getElementById('room-filter');
+  const statusEl = document.getElementById('status-filter');
+  const sortEl = document.getElementById('sort-toggle');
+
   const defaultStatus = 'any';
   const defaultSort = 'due';
 
-  let activeCount = 0;
-  if (room !== 'all') activeCount++;
-  if (status !== defaultStatus) activeCount++;
-  if (sort !== defaultSort) activeCount++;
+  const chips = [];
+  if (roomEl && roomEl.value !== 'all') {
+    chips.push({
+      text: roomEl.options[roomEl.selectedIndex].textContent,
+      remove() { roomEl.value = 'all'; }
+    });
+  }
+  if (statusEl && statusEl.value !== defaultStatus) {
+    chips.push({
+      text: statusEl.options[statusEl.selectedIndex].textContent,
+      remove() { statusEl.value = defaultStatus; }
+    });
+  }
+  if (sortEl && sortEl.value !== defaultSort) {
+    chips.push({
+      text: sortEl.options[sortEl.selectedIndex].textContent,
+      remove() { sortEl.value = defaultSort; }
+    });
+  }
+  document.querySelectorAll('#type-filters input:checked').forEach(cb => {
+    const label = cb.closest('label');
+    chips.push({
+      text: label ? label.textContent.trim() : cb.value,
+      remove() { cb.checked = false; }
+    });
+  });
 
+  if (chipsEl) {
+    chipsEl.innerHTML = '';
+    chips.forEach(c => {
+      const chip = document.createElement('span');
+      chip.className = 'filter-chip';
+      chip.textContent = c.text;
+      const btn = document.createElement('button');
+      btn.innerHTML = ICONS.cancel;
+      btn.addEventListener('click', () => {
+        c.remove();
+        saveFilterPrefs();
+        loadPlants();
+        updateFilterChips();
+      });
+      chip.appendChild(btn);
+      chipsEl.appendChild(chip);
+    });
+  }
+
+  const activeCount = chips.length;
+
+  if (summaryEl) {
+    summaryEl.textContent = activeCount ? `${activeCount} active` : 'No filters';
+  }
   if (filterToggle) {
     filterToggle.innerHTML = ICONS.filter + ' Filters';
     filterToggle.setAttribute('data-count', activeCount);
@@ -2324,4 +2374,4 @@ if (document.readyState === 'loading') {
   init();
 }
 
-export { loadCalendar, focusPlantId, loadPlants };
+export { loadCalendar, focusPlantId, loadPlants, updateFilterChips };


### PR DESCRIPTION
## Summary
- show active filter chips on the toolbar
- generate/removable chips in `updateFilterChips`
- export `updateFilterChips` for tests
- add tests for filter chip UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866030e38988324b6e757c022bd8107