### PR TITLE
Hide search input on scroll

### DIFF
--- a/script.js
+++ b/script.js
@@ -1953,6 +1953,8 @@ async function init(){
   const viewButtons = document.querySelectorAll('#view-toggle .view-toggle-btn');
   const prevBtn = document.getElementById('prev-week');
   const nextBtn = document.getElementById('next-week');
+  const toolbar = document.querySelector('.toolbar');
+  const searchInputEl = document.getElementById('search-input');
 
   const calendarEl = document.getElementById('calendar');
   const calendarHeading = document.getElementById('calendar-heading');
@@ -2083,7 +2085,19 @@ async function init(){
     }
   });
 
-  document.getElementById('search-input').addEventListener('input',loadPlants);
+  if (searchInputEl) searchInputEl.addEventListener('input', loadPlants);
+  if (toolbar) {
+    let lastScrollY = window.scrollY;
+    window.addEventListener('scroll', () => {
+      const current = window.scrollY;
+      if (current > lastScrollY) {
+        toolbar.classList.add('search-collapsed');
+      } else {
+        toolbar.classList.remove('search-collapsed');
+      }
+      lastScrollY = current;
+    });
+  }
   document.getElementById('cancel-edit').onclick=resetForm;
   if (photoDrop && photoInput) {
     function previewFile(file) {

--- a/style.css
+++ b/style.css
@@ -1117,6 +1117,10 @@ button:focus {
   border-radius: var(--radius);
 }
 
+.toolbar.search-collapsed .toolbar__search {
+  display: none;
+}
+
 #search-input {
   border-radius: var(--radius);
   transition: border-color 0.2s, box-shadow 0.2s;


### PR DESCRIPTION
## Summary
- hide the search field when the toolbar has `search-collapsed`
- add toolbar/search elements in `init`
- add scroll handler to toggle `search-collapsed`

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6866617620a483249ccdc8b9ea81147c