### PR TITLE
Add clear search button

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,8 +137,11 @@
     </form>
 
     <div class="toolbar my-4 p-4 bg-card rounded-lg shadow">
-        <label for="search-input" class="sr-only">Search Plants</label>
-        <input type="text" id="search-input" class="toolbar__search" placeholder="Search by name or species" />
+        <div class="search-wrapper">
+            <label for="search-input" class="sr-only">Search Plants</label>
+            <input type="text" id="search-input" class="toolbar__search" placeholder="Search by name or species" />
+            <button type="button" id="clear-search" class="clear-search-btn hidden" aria-label="Clear search"></button>
+        </div>
         <button id="filter-toggle" type="button" class="chip" data-count="0" aria-haspopup="true" aria-expanded="false" aria-controls="filter-panel">Filters</button>
 
         <button id="status-chip" type="button" class="chip active">Needs Care</button>

--- a/script.js
+++ b/script.js
@@ -1955,6 +1955,7 @@ async function init(){
   const nextBtn = document.getElementById('next-week');
   const toolbar = document.querySelector('.toolbar');
   const searchInputEl = document.getElementById('search-input');
+  const clearSearchBtn = document.getElementById('clear-search');
 
   const calendarEl = document.getElementById('calendar');
   const calendarHeading = document.getElementById('calendar-heading');
@@ -2085,7 +2086,26 @@ async function init(){
     }
   });
 
-  if (searchInputEl) searchInputEl.addEventListener('input', loadPlants);
+  if (searchInputEl) {
+    const toggleClear = () => {
+      if (clearSearchBtn) {
+        clearSearchBtn.classList.toggle('hidden', searchInputEl.value === '');
+      }
+    };
+    searchInputEl.addEventListener('input', () => {
+      toggleClear();
+      loadPlants();
+    });
+    if (clearSearchBtn) {
+      clearSearchBtn.innerHTML = ICONS.cancel;
+      clearSearchBtn.addEventListener('click', () => {
+        searchInputEl.value = '';
+        toggleClear();
+        loadPlants();
+      });
+      toggleClear();
+    }
+  }
   if (toolbar) {
     let lastScrollY = window.scrollY;
     window.addEventListener('scroll', () => {

--- a/style.css
+++ b/style.css
@@ -1108,13 +1108,32 @@ button:focus {
   z-index: 10;
 }
 
-.toolbar__search {
+.search-wrapper {
+  position: relative;
   flex: 1 1 250px;
   max-width: 350px;
+}
+
+.toolbar__search {
+  width: 100%;
   padding: 0.5rem;
   background: var(--color-card);
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
+}
+
+.clear-search-btn {
+  position: absolute;
+  right: 0.5rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .toolbar.search-collapsed .toolbar__search {
@@ -1667,7 +1686,7 @@ button:focus {
 }
 
 @media (max-width: 640px) {
-  .toolbar__search {
+  .search-wrapper {
     flex-basis: 100%;
     max-width: none;
   }


### PR DESCRIPTION
## Summary
- wrap search field in toolbar so we can add a "clear" button
- style wrapper and button with responsive layout support
- toggle clear button visibility and reset search in JS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866628681888324a3e5641e8db10197