### PR TITLE
Handle invalid saved filter prefs

### DIFF
--- a/__tests__/chip.test.js
+++ b/__tests__/chip.test.js
@@ -9,12 +9,17 @@ function setupDOM() {
     <select id="status-filter"><option value="any">Needs Care</option></select>
     <select id="sort-toggle"><option value="due">Due Date</option><option value="name">Name</option></select>
     <div id="type-filters"><label>Succulent<input type="checkbox" value="succulent"></label></div>
+    <button id="undo-btn"></button>
+    <button id="cancel-edit"></button>
+    <form id="plant-form"></form>
+    <div id="filter-panel"></div>
   `;
 }
 
 beforeEach(() => {
   jest.resetModules();
   Object.defineProperty(document, 'readyState', { configurable: true, get: () => 'loading' });
+  localStorage.clear();
 });
 
 test('updateFilterChips shows count and chips', async () => {
@@ -33,4 +38,28 @@ test('updateFilterChips shows count and chips', async () => {
   expect(chips.length).toBe(2);
   expect(chips[0].textContent).toContain('Kitchen');
   expect(document.getElementById('filter-toggle').getAttribute('data-count')).toBe('2');
+});
+
+test('invalid saved values are ignored', async () => {
+  setupDOM();
+  localStorage.setItem('roomFilter', 'Garage');
+  localStorage.setItem('sortPref', 'bogus');
+  localStorage.setItem('statusFilter', 'bad');
+  let mod;
+  await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
+  mod.loadFilterPrefs();
+
+  const roomEl = document.getElementById('room-filter');
+  const sortEl = document.getElementById('sort-toggle');
+  const statusEl = document.getElementById('status-filter');
+  expect(roomEl.value).toBe('all');
+  expect(sortEl.value).toBe('due');
+  expect(statusEl.value).toBe('any');
+
+  roomEl.value = 'Unknown';
+  sortEl.value = 'Foo';
+  statusEl.value = 'Bar';
+
+  expect(() => mod.updateFilterChips()).not.toThrow();
+  expect(document.querySelectorAll('#filter-chips .filter-chip').length).toBe(0);
 });

--- a/script.js
+++ b/script.js
@@ -490,9 +490,18 @@ function loadFilterPrefs() {
   const rVal = localStorage.getItem('roomFilter');
   const sVal = localStorage.getItem('sortPref');
   const dVal = localStorage.getItem('statusFilter');
-  if (rf) rf.value = rVal !== null ? rVal : 'all';
-  if (sf) sf.value = sVal !== null ? sVal : 'due';
-  if (df) df.value = dVal !== null ? dVal : 'any';
+  if (rf) {
+    const hasR = rVal !== null && Array.from(rf.options).some(o => o.value === rVal);
+    rf.value = hasR ? rVal : 'all';
+  }
+  if (sf) {
+    const hasS = sVal !== null && Array.from(sf.options).some(o => o.value === sVal);
+    sf.value = hasS ? sVal : 'due';
+  }
+  if (df) {
+    const hasD = dVal !== null && Array.from(df.options).some(o => o.value === dVal);
+    df.value = hasD ? dVal : 'any';
+  }
   const types = JSON.parse(localStorage.getItem('typeFilters') || '[]');
   document.querySelectorAll('#type-filters input').forEach(cb => {
     cb.checked = types.includes(cb.value);
@@ -569,19 +578,19 @@ function updateFilterChips() {
   const defaultSort = 'due';
 
   const chips = [];
-  if (roomEl && roomEl.value !== 'all') {
+  if (roomEl && roomEl.value !== 'all' && roomEl.selectedIndex >= 0) {
     chips.push({
       text: roomEl.options[roomEl.selectedIndex].textContent,
       remove() { roomEl.value = 'all'; }
     });
   }
-  if (statusEl && statusEl.value !== defaultStatus) {
+  if (statusEl && statusEl.value !== defaultStatus && statusEl.selectedIndex >= 0) {
     chips.push({
       text: statusEl.options[statusEl.selectedIndex].textContent,
       remove() { statusEl.value = defaultStatus; }
     });
   }
-  if (sortEl && sortEl.value !== defaultSort) {
+  if (sortEl && sortEl.value !== defaultSort && sortEl.selectedIndex >= 0) {
     chips.push({
       text: sortEl.options[sortEl.selectedIndex].textContent,
       remove() { sortEl.value = defaultSort; }
@@ -2422,4 +2431,4 @@ if (document.readyState === 'loading') {
   init();
 }
 
-export { loadCalendar, focusPlantId, loadPlants, updateFilterChips };
+export { loadCalendar, focusPlantId, loadPlants, updateFilterChips, loadFilterPrefs };


### PR DESCRIPTION
## Summary
- sanitize saved filter preferences in `loadFilterPrefs`
- skip chips for invalid selections in `updateFilterChips`
- export `loadFilterPrefs` for testing
- test invalid preference handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866660e5b4483249f46a88ef0da5f8c