### PR TITLE
Keep toolbar search visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ dropdowns for narrowing the list. You can filter by **room**, show plants that
 need specific **care** (watering or fertilizing), and change the **sort** order.
 Selections apply instantly and the panel hides after you choose an option.
 
+The search box in the toolbar now stays visible while you scroll so you can
+quickly look up plants at any time.
+
 ## Service Worker
 A small service worker caches the key pages and scripts so the app still opens when you're offline. During development you may need to disable the cache or bump the version in `service-worker.js` to pick up changes.
 

--- a/script.js
+++ b/script.js
@@ -2116,14 +2116,10 @@ async function init(){
     }
   }
   if (toolbar) {
+    // keep the search field visible while scrolling
     let lastScrollY = window.scrollY;
     window.addEventListener('scroll', () => {
       const current = window.scrollY;
-      if (current > lastScrollY) {
-        toolbar.classList.add('search-collapsed');
-      } else {
-        toolbar.classList.remove('search-collapsed');
-      }
       lastScrollY = current;
     });
   }

--- a/style.css
+++ b/style.css
@@ -1138,9 +1138,6 @@ button:focus {
   justify-content: center;
 }
 
-.toolbar.search-collapsed .toolbar__search {
-  display: none;
-}
 
 #search-input {
   border: 1px solid var(--color-border-light);


### PR DESCRIPTION
## Summary
- remove `.search-collapsed` styling
- stop toggling `.search-collapsed` from `script.js`
- note persistent search box in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68666a4da7448324b1ae77ca15f0a9bc