### PR TITLE
Add loading spinner for plant grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,6 +194,7 @@
     <div id="toast" class="toast" role="status" aria-live="polite" aria-hidden="true"></div>
 
     <div id="plant-grid" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 p-4"></div>
+    <div id="loading-overlay" class="loading-overlay hidden" aria-hidden="true"></div>
     <button id="archived-link" type="button" class="text-sm hidden"><span class="visually-hidden">Archived</span></button>
 
 

--- a/script.js
+++ b/script.js
@@ -1364,14 +1364,17 @@ async function exportPlantsBoth() {
 
 // --- main render & filter loop ---
 async function loadPlants() {
-  const res = await fetch(`api/get_plants.php${showArchive ? '?archived=1' : ''}`);
-  const plants = await res.json();
-  plantCache = plants;
   const list = document.getElementById('plant-grid');
-  if (list) {
-    list.classList.toggle('list-view', viewMode === 'list');
-    list.classList.toggle('text-view', viewMode === 'text');
-  }
+  toggleLoading(true);
+  if (list) list.classList.add('updating-grid');
+  try {
+    const res = await fetch(`api/get_plants.php${showArchive ? '?archived=1' : ''}`);
+    const plants = await res.json();
+    plantCache = plants;
+    if (list) {
+      list.classList.toggle('list-view', viewMode === 'list');
+      list.classList.toggle('text-view', viewMode === 'text');
+    }
   const selectedRoom = document.getElementById('room-filter').value;
   const statusFilter = document.getElementById('status-filter')
     ? document.getElementById('status-filter').value
@@ -1916,6 +1919,12 @@ async function loadPlants() {
 
   checkArchivedLink(plants);
   loadCalendar(plants);
+  } catch (err) {
+    console.error('Failed to load plants', err);
+  } finally {
+    if (list) list.classList.remove('updating-grid');
+    toggleLoading(false);
+  }
 }
 
 async function checkArchivedLink(plantsList) {

--- a/style.css
+++ b/style.css
@@ -1607,6 +1607,11 @@ button:focus {
   z-index: 10000;
 }
 
+.updating-grid {
+  opacity: 0.5;
+  transition: opacity 0.2s ease;
+}
+
 .loading-overlay::after {
   content: '';
   width: 40px;


### PR DESCRIPTION
## Summary
- show a loading spinner over the grid while plants refresh
- fade grid content during updates
- include loading overlay element in the page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68666a7f5d088324b6ccb3cef083b00e