### PR TITLE
Improve care date labels

### DIFF
--- a/__tests__/dates.test.js
+++ b/__tests__/dates.test.js
@@ -12,13 +12,15 @@ test('addDays adds days correctly', () => {
   expect(d.toISOString().split('T')[0]).toBe('2023-01-06');
 });
 
-test('formatDateShort returns relative labels', () => {
+test('formatDateShort returns labeled dates', () => {
   const today = new Date();
   const todayStr = today.toISOString().split('T')[0];
-  expect(formatDateShort(todayStr)).toBe('today');
+  const todayLabel = today.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' \u2013 today';
+  expect(formatDateShort(todayStr)).toBe(todayLabel);
 
   const yest = new Date(today);
   yest.setDate(today.getDate() - 1);
   const yestStr = yest.toISOString().split('T')[0];
-  expect(formatDateShort(yestStr)).toBe('yesterday');
+  const yestLabel = yest.toLocaleDateString(undefined, { month: 'short', day: 'numeric' }) + ' \u2013 yesterday';
+  expect(formatDateShort(yestStr)).toBe(yestLabel);
 });

--- a/js/dates.js
+++ b/js/dates.js
@@ -24,8 +24,9 @@ export function formatDateShort(dateStr) {
   const dayToFormat = new Date(d);
   dayToFormat.setHours(0, 0, 0, 0);
   const diff = Math.round((dayToFormat - today) / 86400000);
-  if (diff === 0) return 'today';
-  if (diff === -1) return 'yesterday';
-  if (diff === 1) return 'tomorrow';
-  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  const short = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  if (diff === 0) return `${short} \u2013 today`;
+  if (diff === -1) return `${short} \u2013 yesterday`;
+  if (diff === 1) return `${short} \u2013 tomorrow`;
+  return short;
 }


### PR DESCRIPTION
## Summary
- make `formatDateShort` include the calendar date along with today/yesterday/tomorrow labels
- update unit test for the new format

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68666af7d31c8324b0ebb2376fea5d9b