### PR TITLE
Improve Needs Care button styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -1206,6 +1206,17 @@ button:focus {
   border-color: var(--color-primary);
 }
 
+/* Distinct styling for the Needs Care toggle */
+#status-chip {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+  background: transparent;
+}
+
+#status-chip.active {
+  color: var(--color-surface);
+}
+
 
 
 


### PR DESCRIPTION
## Summary
- style Needs Care chip with primary colored outline when inactive
- keep filled look when active so it's distinct from filter chips

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68666aa358888324ba1b02e70ca6b7cc