### PR TITLE
Adjust status chip styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -1205,13 +1205,15 @@ button:focus {
 
 /* Distinct styling for the Needs Care toggle */
 #status-chip {
-  border-color: var(--color-primary);
-  color: var(--color-primary);
+  border-color: var(--color-plant);
+  color: var(--color-plant);
   background: transparent;
 }
 
 #status-chip.active {
   color: var(--color-surface);
+  background: var(--color-plant);
+  border-color: var(--color-plant);
 }
 
 


### PR DESCRIPTION
## Summary
- adjust `#status-chip` colors so active/inactive states use plant green

## Testing
- `phpunit --configuration phpunit.xml --no-coverage`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68666dad2bd083248c8ce4d6f4eba29c