### PR TITLE
Fix status chip activation

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
         </div>
         <button id="filter-toggle" type="button" class="chip" data-count="0" aria-haspopup="true" aria-expanded="false" aria-controls="filter-panel">Filters</button>
 
-        <button id="status-chip" type="button" class="chip active">Needs Care</button>
+        <button id="status-chip" type="button" class="chip">Needs Care</button>
         <select id="sort-toggle" class="hidden">
             <option value="name">Name (A-Z)</option>
             <option value="name-desc">Name (Z-A)</option>

--- a/script.js
+++ b/script.js
@@ -2052,7 +2052,7 @@ async function init(){
     });
   }
   if (statusChip && dueFilterEl) {
-    if (dueFilterEl.value === 'any') statusChip.classList.add('active');
+    statusChip.classList.toggle('active', dueFilterEl.value === 'any');
     statusChip.addEventListener('click', () => {
       const active = statusChip.classList.toggle('active');
       dueFilterEl.value = active ? 'any' : 'all';


### PR DESCRIPTION
## Summary
- ensure status chip active state syncs with stored filter on page load
- remove default `active` from markup

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68666ff4414083249ee569b32d17287d