### PR TITLE
Improve status chip toggle text

### DIFF
--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -101,3 +101,29 @@ test('loadPlants filters by plant type', async () => {
   expect(cards.length).toBe(1);
   expect(cards[0].id).toBe('plant-1');
 });
+
+test('status chip text toggles based on filter', async () => {
+  setupDOM();
+  document.body.innerHTML += `<button id="status-chip" class="chip active">Needs Care</button>`;
+  jest.useFakeTimers().setSystemTime(new Date('2023-01-10'));
+  const plants = [
+    { id: 1, name: 'A', species: 'sp', room: 'Kitchen', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' }
+  ];
+  global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve(plants) });
+  let mod;
+  await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
+
+  const statusChip = document.getElementById('status-chip');
+  const statusFilter = document.getElementById('status-filter');
+
+  statusFilter.value = 'any';
+  statusChip.classList.add('active');
+  await mod.loadPlants();
+  expect(statusChip.textContent).toBe('Needs Care (1)');
+
+  statusFilter.value = 'all';
+  statusChip.classList.remove('active');
+  await mod.loadPlants();
+  expect(statusChip.textContent).toBe('Show All');
+  jest.useRealTimers();
+});

--- a/index.html
+++ b/index.html
@@ -142,9 +142,8 @@
             <input type="text" id="search-input" class="toolbar__search" placeholder="Search by name or species" />
             <button type="button" id="clear-search" class="clear-search-btn hidden" aria-label="Clear search"></button>
         </div>
-        <button id="filter-toggle" type="button" class="chip" data-count="0" aria-haspopup="true" aria-expanded="false" aria-controls="filter-panel">Filters</button>
-
         <button id="status-chip" type="button" class="chip active">Needs Care</button>
+        <button id="filter-toggle" type="button" class="chip" data-count="0" aria-haspopup="true" aria-expanded="false" aria-controls="filter-panel">Filters</button>
         <select id="sort-toggle" class="hidden">
             <option value="name">Name (A-Z)</option>
             <option value="name-desc">Name (Z-A)</option>

--- a/script.js
+++ b/script.js
@@ -1505,8 +1505,11 @@ async function loadPlants() {
 
   const statusChip = document.getElementById('status-chip');
   if (statusChip) {
-    statusChip.textContent = 'Needs Care' +
-      (statusChip.classList.contains('active') ? ` (${needsCareCount})` : '');
+    if (statusChip.classList.contains('active')) {
+      statusChip.textContent = `Needs Care (${needsCareCount})`;
+    } else {
+      statusChip.textContent = 'Show All';
+    }
   }
 
   const sortBy = document.getElementById('sort-toggle').value || 'due';
@@ -2052,12 +2055,17 @@ async function init(){
     });
   }
   if (statusChip && dueFilterEl) {
-    if (dueFilterEl.value === 'any') statusChip.classList.add('active');
+    if (dueFilterEl.value === 'any') {
+      statusChip.classList.add('active');
+    } else {
+      statusChip.textContent = 'Show All';
+    }
     statusChip.addEventListener('click', () => {
       const active = statusChip.classList.toggle('active');
       dueFilterEl.value = active ? 'any' : 'all';
       saveFilterPrefs();
       updateFilterChips();
+      statusChip.textContent = active ? 'Needs Care' : 'Show All';
       loadPlants();
     });
   }


### PR DESCRIPTION
## Summary
- show "Needs Care" count only when the filter is active
- display "Show All" on the status chip when the filter is off
- update chip text instantly on click
- move the needs care chip between the search input and filters button
- test status chip text handling

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686670e815f08324b2b671de924206de