### PR TITLE
Improve filter chip contrast

### DIFF
--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -104,7 +104,7 @@ test('loadPlants filters by plant type', async () => {
 
 test('status chip text toggles based on filter', async () => {
   setupDOM();
-  document.body.innerHTML += `<button id="status-chip" class="chip active">Needs Care</button>`;
+  document.body.innerHTML += `<button id="status-chip" class="btn btn-primary active">Needs Care</button>`;
   jest.useFakeTimers().setSystemTime(new Date('2023-01-10'));
   const plants = [
     { id: 1, name: 'A', species: 'sp', room: 'Kitchen', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' }

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
             <button type="button" id="clear-search" class="clear-search-btn hidden" aria-label="Clear search"></button>
         </div>
 
-        <button id="status-chip" type="button" class="chip active">Needs Care</button>
+        <button id="status-chip" type="button" class="btn btn-primary active">Needs Care</button>
         <button id="filter-toggle" type="button" class="chip" data-count="0" aria-haspopup="true" aria-expanded="false" aria-controls="filter-panel">Filters</button>
 
         <select id="sort-toggle" class="hidden">

--- a/style.css
+++ b/style.css
@@ -27,7 +27,8 @@
   --color-highlight: #faf089;
   --color-warning: #d69e2e;
   --color-success: #38a169;
-  --color-chip-bg: #ecfdf5;
+  /* chip background with 30% opacity of primary color for better contrast */
+  --color-chip-bg: rgba(76, 175, 80, 0.3);
   /* action button colors */
   --color-sprout-bg: #E8F5E9;  /* Green 50 – soft background */
   --color-plant: #388E3C;      /* Green 600 – vibrant leaf */
@@ -1203,17 +1204,16 @@ button:focus {
   border-color: var(--color-primary);
 }
 
-/* Distinct styling for the Needs Care toggle */
+/* Distinct styling for the Needs Care toggle as a filled button */
 #status-chip {
-  border-color: var(--color-plant);
-  color: var(--color-plant);
-  background: transparent;
+  background: var(--color-plant);
+  color: var(--color-surface);
+  border: 1px solid var(--color-plant);
 }
 
-#status-chip.active {
-  color: var(--color-surface);
-  background: var(--color-plant);
-  border-color: var(--color-plant);
+#status-chip:hover,
+#status-chip:focus {
+  filter: brightness(95%);
 }
 
 


### PR DESCRIPTION
## Summary
- improve accessibility by making filter chip backgrounds 30% opacity of the primary green
- make the Needs Care toggle a filled primary button for emphasis

## Testing
- `phpunit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866756f3c9c8324a5507164b5a76fa7