### PR TITLE
Move needs-care alert badge into status button

### DIFF
--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -104,7 +104,7 @@ test('loadPlants filters by plant type', async () => {
 
 test('status chip text toggles based on filter', async () => {
   setupDOM();
-  document.body.innerHTML += `<button id="status-chip" class="btn btn-primary active">Needs Care</button>`;
+  document.body.innerHTML += `<button id="status-chip" class="btn btn-primary active"><span id="status-chip-label">Needs Care</span><span id="needs-care-alert" class="needs-care-alert hidden"></span></button>`;
   jest.useFakeTimers().setSystemTime(new Date('2023-01-10'));
   const plants = [
     { id: 1, name: 'A', species: 'sp', room: 'Kitchen', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' }
@@ -114,23 +114,24 @@ test('status chip text toggles based on filter', async () => {
   await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
 
   const statusChip = document.getElementById('status-chip');
+  const statusLabel = document.getElementById('status-chip-label');
   const statusFilter = document.getElementById('status-filter');
 
   statusFilter.value = 'any';
   statusChip.classList.add('active');
   await mod.loadPlants();
-  expect(statusChip.textContent).toBe('Show All');
+  expect(statusLabel.textContent).toBe('Show All');
 
   statusFilter.value = 'all';
   statusChip.classList.remove('active');
   await mod.loadPlants();
-  expect(statusChip.textContent).toBe('Needs Care (1)');
+  expect(statusLabel.textContent).toBe('Needs Care');
   jest.useRealTimers();
 });
 
 test('needs care alert badge shows count', async () => {
   setupDOM();
-  document.body.innerHTML += `<span id="needs-care-alert" class="needs-care-alert hidden"></span>`;
+  document.body.innerHTML += `<button id="status-chip" class="btn btn-primary"><span id="status-chip-label">Needs Care</span><span id="needs-care-alert" class="needs-care-alert hidden"></span></button>`;
   jest.useFakeTimers().setSystemTime(new Date('2023-01-10'));
   const plants = [
     { id: 1, name: 'A', species: 'sp', room: 'Kitchen', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' }

--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
         My Plant Tracker
         <button id="show-add-form" class="ml-auto"><span class="visually-hidden">Add Plant</span></button>
         <button id="export-all" class="ml-2"><span class="visually-hidden">Export</span></button>
-        <span id="needs-care-alert" class="needs-care-alert hidden"></span>
     </h1>
     <div id="summary" class="p-4 bg-card rounded-lg mb-4">
         <!-- counts will go here -->
@@ -144,7 +143,10 @@
             <button type="button" id="clear-search" class="clear-search-btn hidden" aria-label="Clear search"></button>
         </div>
 
-        <button id="status-chip" type="button" class="btn btn-primary active">Needs Care</button>
+        <button id="status-chip" type="button" class="btn btn-primary active">
+            <span id="status-chip-label">Needs Care</span>
+            <span id="needs-care-alert" class="needs-care-alert hidden"></span>
+        </button>
         <button id="filter-toggle" type="button" class="chip" data-count="0" aria-haspopup="true" aria-expanded="false" aria-controls="filter-panel">Filters</button>
 
         <select id="sort-toggle" class="hidden">

--- a/script.js
+++ b/script.js
@@ -1509,12 +1509,13 @@ async function loadPlants() {
     alertBadge.classList.toggle('hidden', needsCareCount === 0);
   }
 
+  const statusLabel = document.getElementById('status-chip-label');
   const statusChip = document.getElementById('status-chip');
-  if (statusChip) {
+  if (statusChip && statusLabel) {
     if (statusChip.classList.contains('active')) {
-      statusChip.textContent = 'Show All';
+      statusLabel.textContent = 'Show All';
     } else {
-      statusChip.textContent = `Needs Care (${needsCareCount})`;
+      statusLabel.textContent = 'Needs Care';
     }
   }
 
@@ -2060,12 +2061,13 @@ async function init(){
       }
     });
   }
-  if (statusChip && dueFilterEl) {
+  const statusLabel = document.getElementById('status-chip-label');
+  if (statusChip && dueFilterEl && statusLabel) {
     if (dueFilterEl.value === 'any') {
       statusChip.classList.add('active');
-      statusChip.textContent = 'Show All';
+      statusLabel.textContent = 'Show All';
     } else {
-      statusChip.textContent = 'Needs Care';
+      statusLabel.textContent = 'Needs Care';
     }
 
     statusChip.addEventListener('click', () => {
@@ -2073,7 +2075,7 @@ async function init(){
       dueFilterEl.value = active ? 'any' : 'all';
       saveFilterPrefs();
       updateFilterChips();
-      statusChip.textContent = active ? 'Show All' : 'Needs Care';
+      statusLabel.textContent = active ? 'Show All' : 'Needs Care';
       loadPlants();
     });
   }


### PR DESCRIPTION
## Summary
- move the needs-care alert span from the heading into the status chip button
- update JS to toggle the new badge and label text
- adjust tests to reflect new button structure

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686682808e088324817692b480288693