### PR TITLE
Set default status filter to all

### DIFF
--- a/__tests__/chip.test.js
+++ b/__tests__/chip.test.js
@@ -6,7 +6,7 @@ function setupDOM() {
     <div id="filter-chips"></div>
     <span id="filter-summary"></span>
     <select id="room-filter"><option value="all">All Rooms</option><option value="Kitchen">Kitchen</option></select>
-    <select id="status-filter"><option value="any">Needs Care</option></select>
+    <select id="status-filter"><option value="all" selected>All</option><option value="any">Needs Care</option></select>
     <select id="sort-toggle"><option value="due">Due Date</option><option value="name">Name</option></select>
     <div id="type-filters"><label>Succulent<input type="checkbox" value="succulent"></label></div>
     <button id="undo-btn"></button>
@@ -54,7 +54,7 @@ test('invalid saved values are ignored', async () => {
   const statusEl = document.getElementById('status-filter');
   expect(roomEl.value).toBe('all');
   expect(sortEl.value).toBe('due');
-  expect(statusEl.value).toBe('any');
+  expect(statusEl.value).toBe('all');
 
   roomEl.value = 'Unknown';
   sortEl.value = 'Foo';

--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -4,7 +4,7 @@ function setupDOM() {
   document.body.innerHTML = `
     <div id="plant-grid"></div>
     <select id="room-filter"><option value="all">All</option><option value="Kitchen">Kitchen</option><option value="Patio">Patio</option></select>
-    <select id="status-filter"><option value="all">All</option><option value="water">Watering</option><option value="any">Needs Care</option></select>
+    <select id="status-filter"><option value="all" selected>All</option><option value="water">Watering</option><option value="any">Needs Care</option></select>
     <input id="search-input" value="" />
     <div id="summary"></div>
     <select id="sort-toggle"></select>

--- a/index.html
+++ b/index.html
@@ -161,10 +161,10 @@
                     <option value="all" selected>All Rooms</option>
                 </select>
                 <select id="status-filter" class="border rounded-md hidden">
-                    <option value="all">Status: All</option>
+                    <option value="all" selected>Status: All</option>
                     <option value="water">Watering</option>
                     <option value="fert">Fertilizing</option>
-                    <option value="any" selected>Needs Care</option>
+                    <option value="any">Needs Care</option>
                 </select>
                 <div id="type-filters" class="flex flex-wrap gap-2 text-sm">
                     <label class="quick-filter"><input type="checkbox" value="succulent">Succulent</label>

--- a/script.js
+++ b/script.js
@@ -500,7 +500,7 @@ function loadFilterPrefs() {
   }
   if (df) {
     const hasD = dVal !== null && Array.from(df.options).some(o => o.value === dVal);
-    df.value = hasD ? dVal : 'any';
+    df.value = hasD ? dVal : 'all';
   }
   const types = JSON.parse(localStorage.getItem('typeFilters') || '[]');
   document.querySelectorAll('#type-filters input').forEach(cb => {
@@ -574,7 +574,7 @@ function updateFilterChips() {
   const statusEl = document.getElementById('status-filter');
   const sortEl = document.getElementById('sort-toggle');
 
-  const defaultStatus = 'any';
+  const defaultStatus = 'all';
   const defaultSort = 'due';
 
   const chips = [];


### PR DESCRIPTION
## Summary
- default the status filter dropdown to `all`
- ensure loading filter preferences falls back to `all`
- sync chip helper with new default
- update tests for the new default behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68668aa903cc8324b9736ebd47e7a760