### PR TITLE
Show needs-care badge count globally

### DIFF
--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -146,3 +146,23 @@ test('needs care alert badge shows count', async () => {
   expect(badge.classList.contains('hidden')).toBe(false);
   jest.useRealTimers();
 });
+
+test('needs care alert count ignores room filter', async () => {
+  setupDOM();
+  document.body.innerHTML += `<button id="status-chip" class="btn btn-primary"><span id="status-chip-label">Needs Care</span><span id="needs-care-alert" class="needs-care-alert hidden"></span></button>`;
+  jest.useFakeTimers().setSystemTime(new Date('2023-01-10'));
+  const plants = [
+    { id: 1, name: 'A', species: 'sp', room: 'Kitchen', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' },
+    { id: 2, name: 'B', species: 'sp', room: 'Patio', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-05', last_fertilized: null, created_at: '2023-01-01' }
+  ];
+  global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve(plants) });
+  let mod;
+  await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
+
+  document.getElementById('room-filter').value = 'Patio';
+  await mod.loadPlants();
+  const badge = document.getElementById('needs-care-alert');
+  expect(badge.textContent).toBe('1');
+  expect(badge.classList.contains('hidden')).toBe(false);
+  jest.useRealTimers();
+});

--- a/script.js
+++ b/script.js
@@ -1423,6 +1423,12 @@ async function loadPlants() {
 
   list.innerHTML = '';
   let needsCareCount = 0;
+  plants.forEach(plant => {
+    if (needsWatering(plant, today) || needsFertilizing(plant, today)) {
+      needsCareCount++;
+    }
+  });
+
   const filtered = plants.filter(plant => {
     if (selectedRoom !== 'all' && plant.room !== selectedRoom) return false;
     const haystack = (plant.name + ' ' + plant.species).toLowerCase();
@@ -1430,7 +1436,6 @@ async function loadPlants() {
 
     const waterDue = needsWatering(plant, today);
     const fertDue = needsFertilizing(plant, today);
-    if (waterDue || fertDue) needsCareCount++;
     if (statusFilter === 'water' && !waterDue) return false;
     if (statusFilter === 'fert' && !fertDue) return false;
     if (statusFilter === 'any' && !(waterDue || fertDue)) return false;


### PR DESCRIPTION
## Summary
- count plants needing care before applying filters in `loadPlants`
- ensure the needs-care badge ignores filters via new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68668ac290248324be1c0205702bc39c