### PR TITLE
Simplify Needs Care toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,9 @@ Selections apply instantly and the panel hides after you choose an option.
 Next to the search box is a **Needs Care** button that acts as a quick filter.
 The button displays a badge with the number of plants that currently have tasks
 due. Clicking it hides all other plants and shows only those that require
-watering or fertilizing. While active, the button switches to a ghost-style
-**Show All** appearance so you can easily return to the full list with another
-click.
+watering or fertilizing. When the filter is active, the button takes on a
+ghost-style appearance to indicate it's toggled on. Click it again to return to
+the full list.
 
 The search box in the toolbar now stays visible while you scroll so you can
 quickly look up plants at any time.

--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -102,7 +102,7 @@ test('loadPlants filters by plant type', async () => {
   expect(cards[0].id).toBe('plant-1');
 });
 
-test('status chip text toggles based on filter', async () => {
+test('status chip label stays constant while filter toggles', async () => {
   setupDOM();
   document.body.innerHTML += `<button id="status-chip" class="btn btn-primary active"><span id="status-chip-label">Needs Care</span><span id="needs-care-alert" class="needs-care-alert hidden"></span></button>`;
   jest.useFakeTimers().setSystemTime(new Date('2023-01-10'));
@@ -120,7 +120,7 @@ test('status chip text toggles based on filter', async () => {
   statusFilter.value = 'any';
   statusChip.classList.add('active');
   await mod.loadPlants();
-  expect(statusLabel.textContent).toBe('Show All');
+  expect(statusLabel.textContent).toBe('Needs Care');
   expect(statusChip.classList.contains('btn-ghost')).toBe(true);
 
   statusFilter.value = 'all';

--- a/script.js
+++ b/script.js
@@ -1518,7 +1518,7 @@ async function loadPlants() {
   const statusChip = document.getElementById('status-chip');
   if (statusChip && statusLabel) {
     const active = statusChip.classList.contains('active');
-    statusLabel.textContent = active ? 'Show All' : 'Needs Care';
+    statusLabel.textContent = 'Needs Care';
     statusChip.classList.toggle('btn-ghost', active);
     statusChip.classList.toggle('btn-primary', !active);
   }
@@ -2071,16 +2071,14 @@ async function init(){
     if (dueFilterEl.value === 'any') {
       statusChip.classList.add('active', 'btn-ghost');
       statusChip.classList.remove('btn-primary');
-      statusLabel.textContent = 'Show All';
     } else {
       statusChip.classList.remove('btn-ghost');
       statusChip.classList.add('btn-primary');
-      statusLabel.textContent = 'Needs Care';
     }
 
     const isNeedsCare = dueFilterEl.value === 'any';
     statusChip.classList.toggle('active', isNeedsCare);
-    statusLabel.textContent = isNeedsCare ? 'Show All' : 'Needs Care';
+    statusLabel.textContent = 'Needs Care';
 
 
     statusChip.addEventListener('click', () => {
@@ -2090,7 +2088,7 @@ async function init(){
       updateFilterChips();
       statusChip.classList.toggle('btn-ghost', active);
       statusChip.classList.toggle('btn-primary', !active);
-      statusLabel.textContent = active ? 'Show All' : 'Needs Care';
+      statusLabel.textContent = 'Needs Care';
       loadPlants();
     });
   }


### PR DESCRIPTION
## Summary
- keep Needs Care label constant when toggling filter
- update README wording for the Needs Care button
- adjust tests for new behaviour

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68668fbb96e88324abd4f0575a98a2f2