### PR TITLE
Fix water due button contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -508,8 +508,13 @@ button:focus {
 }
 
 .water-due {
-    background-color: #ffffff; /* white background for due button */
-    color: var(--color-primary);
+    background-color: var(--color-water-bg);
+    color: var(--color-water);
+}
+
+.water-due:hover,
+.water-due:focus {
+    color: var(--color-water-hover);
 }
 
 .fert-due {


### PR DESCRIPTION
## Summary
- use water palette variables for `.water-due`
- add hover/focus style to match other action buttons

## Testing
- `phpunit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68673b1e5bf88324bbf53b51ff303ca6