### PR TITLE
Add Clear Filters control

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,6 +142,7 @@
             <input type="text" id="search-input" class="toolbar__search" placeholder="Search by name or species" />
             <button type="button" id="clear-search" class="clear-search-btn hidden" aria-label="Clear search"></button>
         </div>
+        <button type="button" id="clear-filters" class="clear-filters hidden">Clear Filters</button>
 
         <button id="filter-toggle" type="button" class="chip" data-count="0" aria-haspopup="true" aria-expanded="false" aria-controls="filter-panel">Filters</button>
 

--- a/script.js
+++ b/script.js
@@ -567,6 +567,7 @@ function updateFilterChips() {
   const filterToggle = document.getElementById('filter-toggle');
   const chipsEl = document.getElementById('filter-chips');
   const summaryEl = document.getElementById('filter-summary');
+  const clearBtn = document.getElementById('clear-filters');
 
   const roomEl = document.getElementById('room-filter');
   const statusEl = document.getElementById('status-filter');
@@ -632,6 +633,9 @@ function updateFilterChips() {
   if (filterToggle) {
     filterToggle.innerHTML = ICONS.filter + ' Filters';
     filterToggle.setAttribute('data-count', activeCount);
+  }
+  if (clearBtn) {
+    clearBtn.classList.toggle('hidden', activeCount === 0);
   }
   return activeCount;
 }
@@ -2008,6 +2012,7 @@ async function init(){
   const toolbar = document.querySelector('.toolbar');
   const searchInputEl = document.getElementById('search-input');
   const clearSearchBtn = document.getElementById('clear-search');
+  const clearFiltersBtn = document.getElementById('clear-filters');
   const segButtons = document.querySelectorAll('#status-segments button');
 
   const calendarEl = document.getElementById('calendar');
@@ -2421,6 +2426,19 @@ async function init(){
       updateFilterChips();
     });
   });
+
+  if (clearFiltersBtn) {
+    clearFiltersBtn.addEventListener('click', () => {
+      if (roomFilter) roomFilter.value = 'all';
+      if (dueFilterEl) dueFilterEl.value = 'all';
+      document.querySelectorAll('#type-filters input').forEach(cb => {
+        cb.checked = false;
+      });
+      saveFilterPrefs();
+      loadPlants();
+      updateFilterChips();
+    });
+  }
 
 
 

--- a/style.css
+++ b/style.css
@@ -1744,6 +1744,19 @@ button:focus {
 }
 #archived-link.hidden { display: none; }
 
+#clear-filters {
+  font-size: 0.875rem;
+  margin-left: calc(var(--spacing) * 1);
+  color: var(--color-text);
+  background: none;
+  border: none;
+  text-decoration: underline;
+  cursor: pointer;
+  padding: 0;
+}
+
+#clear-filters.hidden { display: none; }
+
 .suggestions {
   position: absolute;
   top: 100%;


### PR DESCRIPTION
## Summary
- add Clear Filters button in toolbar
- style button as a simple link
- toggle Clear Filters visibility based on active filters
- allow clearing all filters at once

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68675fc61f84832491e10f1eb2ff2f96