### PR TITLE
Add inactive badge color for segmented control

### DIFF
--- a/style.css
+++ b/style.css
@@ -29,6 +29,8 @@
   --color-success: #38a169;
   /* chip background with 30% opacity of primary color for better contrast */
   --color-chip-bg: rgba(76, 175, 80, 0.3);
+  /* inactive badge background */
+  --color-badge-inactive: #e0ede3;
   /* action button colors */
   --color-sprout-bg: #E8F5E9;  /* Green 50 – soft background */
   --color-plant: #388E3C;      /* Green 600 – vibrant leaf */
@@ -437,7 +439,7 @@ button:focus {
 }
 
 .segmented-control .count-badge {
-    background: var(--color-chip-bg);
+    background: var(--color-badge-inactive);
     border-radius: 9999px;
     padding: 2px 6px;
     font-size: var(--font-size-sm);


### PR DESCRIPTION
## Summary
- add `--color-badge-inactive` variable
- use the new variable for `.segmented-control .count-badge`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686768c191488324af3f046707544334