### PR TITLE
Add aria-pressed for summary filters

### DIFF
--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -192,6 +192,9 @@ test('summary item click updates status filter', async () => {
   const waterItem = document.querySelector('#summary .summary-item[data-status="water"]');
   waterItem.click();
   expect(document.getElementById('status-filter').value).toBe('water');
+  expect(waterItem.getAttribute('aria-pressed')).toBe('true');
+  const other = document.querySelector('#summary .summary-item[data-status="all"]');
+  expect(other.getAttribute('aria-pressed')).toBe('false');
 });
 
 test('segment totals persist across filtering', async () => {

--- a/script.js
+++ b/script.js
@@ -1489,6 +1489,7 @@ async function loadPlants() {
     span.classList.add('summary-item');
     span.dataset.status = item.status;
     span.setAttribute('role', 'button');
+    span.setAttribute('aria-pressed', item.status === statusFilter);
     span.tabIndex = 0;
     span.innerHTML = item.html;
     if (item.status === statusFilter) {
@@ -1500,6 +1501,9 @@ async function loadPlants() {
         dueInput.value = item.status;
         dueInput.dispatchEvent(new Event('change', { bubbles: true }));
       }
+      row1.querySelectorAll('.summary-item').forEach(s => {
+        s.setAttribute('aria-pressed', s === span);
+      });
     });
     span.addEventListener('keydown', (e) => {
       if (e.key === 'Enter' || e.key === ' ') {


### PR DESCRIPTION
## Summary
- mark summary badges with `aria-pressed` when active
- toggle the attribute when badges are clicked
- test the new attribute in the filter tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686768c5e2888324a7685d4137167aa5