### PR TITLE
Improve filter badges and chip counts

### DIFF
--- a/script.js
+++ b/script.js
@@ -22,6 +22,13 @@ let showArchive = false;
 let archivedCache = null;
 let plantCache = [];
 
+// track counts for active filters
+let filterCounts = {
+  watering: 0,
+  fertilizing: 0,
+  needsCare: 0,
+};
+
 // preferred layout for plant cards
 let viewMode = localStorage.getItem('viewMode') || 'grid';
 const FILTER_PREF_VERSION = 2;
@@ -597,8 +604,12 @@ function updateFilterChips() {
       statusEl.value !== defaultStatus &&
       statusEl.value !== 'any' &&
       statusEl.selectedIndex >= 0) {
+    const val = statusEl.value;
+    let label = statusEl.options[statusEl.selectedIndex].textContent;
+    if (val === 'water') label += ` (${filterCounts.watering})`;
+    if (val === 'fert') label += ` (${filterCounts.fertilizing})`;
     chips.push({
-      text: statusEl.options[statusEl.selectedIndex].textContent,
+      text: label,
       remove() { statusEl.value = defaultStatus; }
     });
   }
@@ -1452,12 +1463,16 @@ async function loadPlants() {
     if (needsFertilizing(plant, today)) fertilizingDue++;
   });
 
+  filterCounts.watering = wateringDue;
+  filterCounts.fertilizing = fertilizingDue;
+
   let needsCareCount = 0;
   plants.forEach(plant => {
     if (needsWatering(plant, today) || needsFertilizing(plant, today)) {
       needsCareCount++;
     }
   });
+  filterCounts.needsCare = needsCareCount;
 
   const filtered = plants.filter(plant => {
     if (selectedRoom !== 'all' && plant.room !== selectedRoom) return false;

--- a/style.css
+++ b/style.css
@@ -1561,19 +1561,21 @@ button:focus {
   cursor: pointer;
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius);
+  background-color: var(--color-badge-inactive);
+  color: var(--color-text);
 }
 
-#summary .summary-item[data-status="all"] {
+#summary .summary-item[data-status="all"].active {
   background-color: var(--color-success-bg);
   color: var(--color-success);
 }
 
-#summary .summary-item[data-status="water"] {
+#summary .summary-item[data-status="water"].active {
   background-color: var(--color-water-bg);
   color: var(--color-water);
 }
 
-#summary .summary-item[data-status="fert"] {
+#summary .summary-item[data-status="fert"].active {
   background-color: var(--color-sprout-bg);
   color: var(--color-plant);
 }
@@ -1588,8 +1590,7 @@ button:focus {
 }
 
 #summary .summary-item.active {
-  background: var(--color-primary);
-  color: var(--color-surface);
+  border: 1px solid var(--color-primary);
 }
 
 #rainfall-info .summary-item {


### PR DESCRIPTION
## Summary
- restyle summary filter badges so only the active badge is highlighted
- show watering and fertilizing counts in the active filter chip

## Testing
- `npm test` *(fails: Cannot find module jest)*

------
https://chatgpt.com/codex/tasks/task_e_68676bca54b483248c4ccd78cffb0776