### PR TITLE
Adjust inactive badge color

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,7 +30,7 @@
   /* chip background with 30% opacity of primary color for better contrast */
   --color-chip-bg: rgba(76, 175, 80, 0.3);
   /* inactive badge background */
-  --color-badge-inactive: #e0ede3;
+  --color-badge-inactive: #ffffff;
   /* action button colors */
   --color-sprout-bg: #E8F5E9;  /* Green 50 – soft background */
   --color-plant: #388E3C;      /* Green 600 – vibrant leaf */


### PR DESCRIPTION
## Summary
- use a white color for `--color-badge-inactive` so filter badges are white when inactive

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68676e03f52c8324a56bfe7b73d79a11