### PR TITLE
Revert water color palette

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -41,9 +41,9 @@ function drawChart(data) {
           label: 'Water (mL)',
           data: water,
           yAxisID: 'y2',
-          borderColor: '#2196F3',
+          borderColor: '#3182ce',
           fill: true,
-          backgroundColor: 'rgba(33,150,243,0.2)'
+          backgroundColor: 'rgba(49,130,206,0.2)'
         }
       ]
     },

--- a/style.css
+++ b/style.css
@@ -19,8 +19,8 @@
   --color-error-bg: #fff5f5;
   --color-warning-bg: #fefcbf;
   --color-success-bg: #f0fff4;
- --color-water-bg:   #E3F2FD;  /* Blue 50 – very light, clean background */
-  --color-water:      #2196F3;  /* Blue 500 – vivid water drop fill */
+ --color-water-bg: #ebf8ff;  /* Lighter blue background */
+  --color-water:  #3182ce;  /* Primary blue for water icons */
   --color-water-hover:#1976D2;  /* Blue 700 – for hover or active states */
   /* fertilizing due indicator now uses a white background */
   --color-fert-bg: #ffffff;


### PR DESCRIPTION
## Summary
- revert the water blue shades back to the prior palette in `style.css`
- update analytics line colors to match reverted water palette

## Testing
- `npm test`
- `phpunit -c phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6867723716b08324abcfb04661f2eb78