### PR TITLE
Improve water summary styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -542,8 +542,17 @@ button:focus {
 }
 
 .water-due {
-    background-color: #ffffff; /* white background for due button */
-    color: var(--color-primary);
+    background-color: var(--color-water-bg);
+    border: 1px solid var(--color-water-hover);
+    color: var(--color-water-hover);
+}
+
+.water-due:hover,
+.water-due:focus,
+.water-due:active {
+    background-color: var(--color-water-bg);
+    border-color: var(--color-water-hover);
+    color: var(--color-water-hover);
 }
 
 .fert-due {
@@ -1591,7 +1600,7 @@ button:focus {
 }
 
 #summary .summary-item[data-status="water"]:hover {
-  border-color: var(--color-water);
+  border-color: var(--color-water-hover);
 }
 
 #summary .summary-item:focus {
@@ -1604,7 +1613,7 @@ button:focus {
 }
 
 #summary .summary-item[data-status="water"].active {
-  border-color: var(--color-water);
+  border-color: var(--color-water-hover);
 }
 
 #summary .summary-item[data-status="all"].active,
@@ -1654,6 +1663,12 @@ button:focus {
 
 .icon-water {
   color: var(--color-water);
+}
+
+.icon-water path {
+  fill: var(--color-water-bg);
+  stroke: var(--color-water-hover);
+  stroke-width: 1px;
 }
 
 .icon-rain {


### PR DESCRIPTION
## Summary
- style water-due buttons with blue borders and background
- emphasize water summary hover/active state borders
- give water icons a blue outline and light fill

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867c45a9bd083248eefd6e6c8b88f8b