### PR TITLE
Fix water summary color

### DIFF
--- a/style.css
+++ b/style.css
@@ -1582,7 +1582,7 @@ button:focus {
 
 #summary .summary-item[data-status="water"].active {
   background-color: var(--color-water-bg);
-  color: var(--color-water);
+  color: var(--color-water-hover);
 }
 
 #summary .summary-item[data-status="fert"].active {
@@ -1614,6 +1614,10 @@ button:focus {
 
 #summary .summary-item[data-status="water"].active {
   border-color: var(--color-water-hover);
+}
+
+#summary .summary-item[data-status="water"].active .icon {
+  color: var(--color-water-hover);
 }
 
 #summary .summary-item[data-status="all"].active,


### PR DESCRIPTION
## Summary
- make text and icon in active water summary blue

## Testing
- `npm test`
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6867c68b2964832481e6a71fcbf79736