### PR TITLE
Restore water-due event colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -836,7 +836,7 @@ button:focus {
 
 #calendar .cal-event.water-due {
   background-color: var(--color-water-bg);
-  color: var(--color-water);
+  color: #1976D2;
 }
 
 #calendar .cal-event.fert-due {


### PR DESCRIPTION
## Summary
- restore blue background for `.cal-event.water-due`
- set water-due text color to hex value `#1976D2`

## Testing
- `npm install`
- `npm test`
- ❌ `phpunit` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c8be5f388324ba55837272c27f49