### PR TITLE
Move password check to PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Plant Tracker is a small PHP web app that helps you keep your houseplants health
 ```php
 'openweather_key' => 'YOUR_API_KEY',
 'location'        => 'City,Country',
+'auth_password'   => 'plants123',
 'kc'              => 0.8,
 'kc_map' => [
     'succulent'  => 0.3,
@@ -55,6 +56,7 @@ Plant Tracker is a small PHP web app that helps you keep your houseplants health
     ],
 ],
 ```
+The `auth_password` value sets the password for the login overlay on `index.html`. Change it in your `config.php` if you want a different credential.
 
    Extraterrestrial radiation (RA) is calculated automatically from the
    latitude returned by OpenWeather and the current day of year, so no

--- a/api/login.php
+++ b/api/login.php
@@ -1,0 +1,27 @@
+<?php
+if (PHP_SAPI !== 'cli' && session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+if (!headers_sent()) {
+    header('Content-Type: application/json');
+}
+$configFile = __DIR__ . '/../config.php';
+if (!file_exists($configFile)) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Config file missing']);
+    exit;
+}
+$config = include $configFile;
+$expected = $config['auth_password'] ?? 'plants123';
+$input = json_decode(file_get_contents('php://input'), true);
+$pw = $input['password'] ?? ($_POST['password'] ?? '');
+if ($pw === $expected) {
+    $_SESSION['logged_in'] = true;
+    echo json_encode(['success' => true]);
+} else {
+    if (PHP_SAPI !== 'cli') {
+        http_response_code(401);
+    }
+    echo json_encode(['error' => 'Invalid credentials']);
+}
+?>

--- a/config.example.php
+++ b/config.example.php
@@ -2,6 +2,8 @@
 return [
     'openweather_key' => 'YOUR_API_KEY',
     'location'        => 'City,Country',
+    // default password for the simple login overlay
+    'auth_password'   => 'plants123',
     'kc'              => 0.8,
     'kc_map' => [
         'succulent'  => 0.3,

--- a/index.html
+++ b/index.html
@@ -248,15 +248,25 @@
           showOverlay();
         }
       }
-      document.getElementById('login-btn').addEventListener('click', () => {
+      async function attemptLogin() {
         const pw = document.getElementById('login-pass').value;
-        if (pw === 'plants123') {
-          localStorage.setItem('pt_logged_in', 'yes');
-          hideOverlay();
-        } else {
-          alert('Incorrect password');
+        try {
+          const res = await fetch('api/login.php', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ password: pw })
+          });
+          if (res.ok) {
+            localStorage.setItem('pt_logged_in', 'yes');
+            hideOverlay();
+          } else {
+            alert('Incorrect password');
+          }
+        } catch (e) {
+          alert('Login failed');
         }
-      });
+      }
+      document.getElementById('login-btn').addEventListener('click', attemptLogin);
       window.addEventListener('load', checkLogin);
     </script>
 

--- a/tests/LoginTest.php
+++ b/tests/LoginTest.php
@@ -1,0 +1,42 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class LoginTest extends TestCase
+{
+    private $configFile;
+
+    protected function setUp(): void
+    {
+        $this->configFile = __DIR__ . '/../config.php';
+        file_put_contents($this->configFile, "<?php return ['auth_password' => 'secret'];");
+        putenv('TESTING=1');
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->configFile)) {
+            unlink($this->configFile);
+        }
+    }
+
+    public function testLoginSuccess()
+    {
+        $_POST = ['password' => 'secret'];
+        ob_start();
+        include __DIR__ . '/../api/login.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertTrue($data['success']);
+    }
+
+    public function testLoginFailure()
+    {
+        $_POST = ['password' => 'wrong'];
+        ob_start();
+        include __DIR__ . '/../api/login.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertArrayHasKey('error', $data);
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- add `auth_password` setting
- create `api/login.php` for password validation
- use fetch login request in `index.html`
- document the new config key
- add PHPUnit tests for login

## Testing
- `npm test`
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68686f69922483249416f355bee0bb7f