### PR TITLE
Move export button and style add button

### DIFF
--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -11,7 +11,6 @@ function setupDOM() {
       <div id="summary-counts"></div>
       <div id="summary-date"></div>
       <div id="summary-weather"></div>
-      <button id="export-all"></button>
     </header>
     <select id="sort-toggle"></select>
 
@@ -31,6 +30,8 @@ function setupDOM() {
 
     <div id="location-filters"><label><input type="checkbox" value="outside" /></label><label><input type="checkbox" value="inside" checked /></label></div>
     <div id="type-filters"><label><input type="checkbox" value="succulent" />Succulent</label><label><input type="checkbox" value="herb" />Herb</label></div>
+
+    <footer><button id="export-all"></button></footer>
 
   `;
 }

--- a/index.html
+++ b/index.html
@@ -27,7 +27,6 @@
         <div id="summary-counts" class="col-span-2 md:col-span-1 flex flex-wrap gap-4"></div>
         <div id="summary-date" class="col-span-1"></div>
         <div id="summary-weather" class="col-span-1"></div>
-        <button id="export-all" class="col-span-1"><span class="visually-hidden">Export</span></button>
     </header>
 
 
@@ -213,7 +212,12 @@
         <button id="prev-week" class="btn btn-primary"><span class="visually-hidden">Previous Week</span></button>
         <button id="next-week" class="btn btn-primary"><span class="visually-hidden">Next Week</span></button>
     </div>
+
     <div id="calendar" class="p-4"></div>
+
+    <footer class="p-4 bg-card rounded-lg mt-4 text-right">
+        <button id="export-all"><span class="visually-hidden">Export</span></button>
+    </footer>
 
 
     <script type="module" src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -176,6 +176,16 @@ h1 {
 #show-add-form {
   background: var(--color-primary);
   color: var(--color-surface);
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  width: 3.5rem;
+  height: 3.5rem;
+  padding: 0;
+  border-radius: 50%;
+  justify-content: center;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  z-index: 100;
 }
 
 #show-add-form:hover,


### PR DESCRIPTION
## Summary
- relocate Export button to page footer
- style Add Plant button as a floating action button
- update filter tests to account for new footer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686875dc647c83248bcf54fd2504da31