### PR TITLE
Align date & weather summary

### DIFF
--- a/style.css
+++ b/style.css
@@ -1578,8 +1578,12 @@ button:focus {
 #summary-counts {
   display: flex;
   flex-wrap: wrap;
-  width: 100%;
+  flex-grow: 1;
   gap: calc(var(--spacing) * 1.5);
+}
+
+#summary-date {
+  margin-left: auto;
 }
 
 .summary-row {


### PR DESCRIPTION
## Summary
- keep summary items in one flex row
- right-align the date and weather in the header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6868889ec1c883249eefbc0c6ac99967