### PR TITLE
Fix weather summary wrapping

### DIFF
--- a/style.css
+++ b/style.css
@@ -1569,7 +1569,7 @@ button:focus {
 
 #summary {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: flex-start;
   gap: var(--spacing);
   background: transparent;
@@ -1689,8 +1689,8 @@ button:focus {
 }
 
 .weather-icon {
-  width: 3em;
-  height: 3em;
+  width: 1em;
+  height: 1em;
   vertical-align: -0.125em;
 }
 


### PR DESCRIPTION
## Summary
- keep summary section on a single row
- shrink the weather icon so it doesn't push text to a new line

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68688af48d28832493054808b2a6c500