### PR TITLE
Fix weather icon layout with scaling

### DIFF
--- a/style.css
+++ b/style.css
@@ -1692,6 +1692,8 @@ button:focus {
   width: 1em;
   height: 1em;
   vertical-align: -0.125em;
+  transform: scale(3);
+  transform-origin: left center;
 }
 
 


### PR DESCRIPTION
## Summary
- enlarge the `.weather-icon` with `transform: scale(3)` so the icon is larger while preserving layout

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68688e2cf684832484532402ac9641fb