### PR TITLE
Improve mobile summary layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,11 +22,13 @@
         </div>
     </div>
     <h1 class="visually-hidden">My Plant Tracker</h1>
-    <header id="summary" class="p-4 bg-card rounded-lg mb-4 grid grid-cols-2 md:grid-cols-5 gap-4 items-center">
-        <button id="show-add-form" class="col-span-1"><span class="visually-hidden">Add Plant</span></button>
-        <div id="summary-counts" class="col-span-2 md:col-span-1 flex flex-wrap gap-4"></div>
-        <div id="summary-date" class="col-span-1"></div>
-        <div id="summary-weather" class="col-span-1"></div>
+    <header id="summary" class="p-4 bg-card rounded-lg mb-4">
+        <button id="show-add-form"><span class="visually-hidden">Add Plant</span></button>
+        <div id="summary-counts"></div>
+        <div id="summary-info" class="summary-row">
+            <div id="summary-date"></div>
+            <div id="summary-weather"></div>
+        </div>
     </header>
 
 

--- a/style.css
+++ b/style.css
@@ -1575,6 +1575,12 @@ button:focus {
   background: transparent;
 }
 
+#summary-info {
+  display: flex;
+  gap: calc(var(--spacing) * 1.5);
+  align-items: center;
+}
+
 #summary-counts {
   display: flex;
   flex-wrap: wrap;
@@ -1583,7 +1589,13 @@ button:focus {
 }
 
 #summary-date {
-  margin-left: auto;
+  margin-left: 0;
+}
+
+@media (min-width: 640px) {
+  #summary-date {
+    margin-left: auto;
+  }
 }
 
 .summary-row {
@@ -1692,6 +1704,20 @@ button:focus {
   width: 1em;
   height: 1em;
   vertical-align: -0.125em;
+}
+
+@media (max-width: 640px) {
+  #summary {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  #summary-counts {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  #summary-date {
+    margin-left: 0;
+  }
 }
 
 


### PR DESCRIPTION
## Summary
- restyle summary header for a stacked mobile layout
- group date and weather info
- tweak CSS for responsive behavior

## Testing
- `npm test`
- `phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68688fb6e7ec8324960d1ca241bb41cf