### PR TITLE
Fix weather icon overlap

### DIFF
--- a/style.css
+++ b/style.css
@@ -1701,11 +1701,10 @@ button:focus {
 }
 
 .weather-icon {
-  width: 1em;
-  height: 1em;
+  width: 3em;
+  height: 3em;
   vertical-align: -0.125em;
-  transform: scale(3);
-  transform-origin: left center;
+  margin-right: 0.25em;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- enlarge `.weather-icon` to allocate width/height and add margin

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686891fce5308324a8dd042801484faa