### PR TITLE
Fix mobile summary layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -1714,7 +1714,7 @@ button:focus {
     align-items: flex-start;
   }
   #summary-counts {
-    flex-direction: column;
+    flex-direction: row;
     align-items: flex-start;
   }
   #summary-date {


### PR DESCRIPTION
## Summary
- keep summary-counts in a row on small screens

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6868930893c08324843dc09fa78b65dc