### PR TITLE
Improve mobile summary layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -1487,13 +1487,14 @@ async function loadPlants() {
 
   if (countsEl) countsEl.innerHTML = '';
   const row1Items = [
-    { html: `${ICONS.plant} ${totalPlants} plants`, status: 'all' },
-    { html: `${ICONS.water} ${wateringDue} need watering`, status: 'water' },
-    { html: `${ICONS.fert} ${fertilizingDue} need fertilizing`, status: 'fert' }
+    { html: `${ICONS.plant} ${totalPlants} plants`, status: 'all', cls: 'summary-plants' },
+    { html: `${ICONS.water} ${wateringDue} need watering`, status: 'water', cls: 'summary-water' },
+    { html: `${ICONS.fert} ${fertilizingDue} need fertilizing`, status: 'fert', cls: 'summary-fert' }
   ];
   row1Items.forEach(item => {
     const span = document.createElement('span');
     span.classList.add('summary-item');
+    if (item.cls) span.classList.add(item.cls);
     span.dataset.status = item.status;
     span.setAttribute('role', 'button');
     span.setAttribute('aria-pressed', item.status === statusFilter);

--- a/style.css
+++ b/style.css
@@ -1713,9 +1713,16 @@ button:focus {
     align-items: flex-start;
   }
   #summary-counts {
-    flex-direction: row;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      "plants plants"
+      "water fert";
     align-items: flex-start;
   }
+  #summary-counts .summary-plants { grid-area: plants; }
+  #summary-counts .summary-water { grid-area: water; }
+  #summary-counts .summary-fert { grid-area: fert; }
   #summary-date {
     margin-left: 0;
   }


### PR DESCRIPTION
## Summary
- add CSS grid areas to arrange summary counts
- mark each summary item with a class for the grid area

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686894f96818832488610393adc9ba8d