### PR TITLE
Secure API endpoints with session checks

### DIFF
--- a/api/add_plant.php
+++ b/api/add_plant.php
@@ -13,6 +13,21 @@ if ($debug) {
     error_reporting(E_ALL);
 }
 
+if (PHP_SAPI !== 'cli' && session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    @http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
+}
+
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }

--- a/api/archive_plant.php
+++ b/api/archive_plant.php
@@ -10,6 +10,20 @@ if ($dbConfig && file_exists($dbConfig)) {
 } else {
     include '../db.php';
 }
+if (PHP_SAPI !== 'cli' && session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    @http_response_code(401);
+    echo json_encode(['status' => 'error', 'error' => 'Unauthorized']);
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
+}
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }

--- a/api/delete_plant.php
+++ b/api/delete_plant.php
@@ -12,6 +12,21 @@ if ($debug) {
     error_reporting(E_ALL);
 }
 
+if (PHP_SAPI !== 'cli' && session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    @http_response_code(401);
+    echo json_encode(['success' => false, 'error' => 'Unauthorized']);
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
+}
+
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }

--- a/api/export_plants_csv.php
+++ b/api/export_plants_csv.php
@@ -11,6 +11,21 @@ if ($dbConfig && file_exists($dbConfig)) {
     include '../db.php';
 }
 
+if (PHP_SAPI !== 'cli' && session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    @http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
+}
+
 if (!headers_sent()) {
     header('Content-Type: text/csv');
     header('Content-Disposition: attachment; filename="plants.csv"');

--- a/api/get_et0_timeseries.php
+++ b/api/get_et0_timeseries.php
@@ -11,6 +11,21 @@ if ($dbConfig && file_exists($dbConfig)) {
     include '../db.php';
 }
 
+if (PHP_SAPI !== 'cli' && session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    @http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
+}
+
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }

--- a/api/get_plants.php
+++ b/api/get_plants.php
@@ -11,6 +11,21 @@ if ($dbConfig && file_exists($dbConfig)) {
     include '../db.php';
 }
 
+if (PHP_SAPI !== 'cli' && session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    @http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
+}
+
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }

--- a/api/log_et0.php
+++ b/api/log_et0.php
@@ -11,6 +11,21 @@ if ($dbConfig && file_exists($dbConfig)) {
     include '../db.php';
 }
 
+if (PHP_SAPI !== 'cli' && session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    @http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
+}
+
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }

--- a/api/mark_fertilized.php
+++ b/api/mark_fertilized.php
@@ -11,6 +11,21 @@ if ($dbConfig && file_exists($dbConfig)) {
     include '../db.php';
 }
 
+if (PHP_SAPI !== 'cli' && session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    @http_response_code(401);
+    echo json_encode(['status' => 'error', 'error' => 'Unauthorized']);
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
+}
+
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }

--- a/api/mark_watered.php
+++ b/api/mark_watered.php
@@ -11,6 +11,21 @@ if ($dbConfig && file_exists($dbConfig)) {
     include '../db.php';
 }
 
+if (PHP_SAPI !== 'cli' && session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    @http_response_code(401);
+    echo json_encode(['status' => 'error', 'error' => 'Unauthorized']);
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
+}
+
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }

--- a/api/update_plant.php
+++ b/api/update_plant.php
@@ -13,6 +13,21 @@ if ($debug) {
     error_reporting(E_ALL);
 }
 
+if (PHP_SAPI !== 'cli' && session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    @http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
+}
+
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }

--- a/api/weather.php
+++ b/api/weather.php
@@ -1,4 +1,18 @@
 <?php
+if (PHP_SAPI !== 'cli' && session_status() !== PHP_SESSION_ACTIVE) {
+    session_start();
+}
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
+    @http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    if (!getenv('TESTING')) {
+        exit;
+    }
+    return;
+}
 if (!headers_sent()) {
     header('Content-Type: application/json');
 }

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -9,6 +9,7 @@ class ApiTest extends TestCase
         $this->dbConfig = __DIR__ . '/db_stub.php';
         putenv('DB_CONFIG=' . $this->dbConfig);
         putenv('TESTING=1');
+        $_SESSION['logged_in'] = true;
     }
 
     public function testAddPlantMissingName()
@@ -200,6 +201,28 @@ class ApiTest extends TestCase
         $output = ob_get_clean();
         $data = json_decode($output, true);
         $this->assertEquals('success', $data['status']);
+    }
+
+    public function testUnauthorizedAddPlant()
+    {
+        $_SESSION['logged_in'] = false;
+        $_POST = ['name' => 'Fail', 'watering_frequency' => 1];
+        ob_start();
+        include __DIR__ . '/../api/add_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('Unauthorized', $data['error']);
+    }
+
+    public function testUnauthorizedDeletePlant()
+    {
+        $_SESSION['logged_in'] = false;
+        $_POST = ['id' => 1];
+        ob_start();
+        include __DIR__ . '/../api/delete_plant.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('Unauthorized', $data['error']);
     }
 }
 ?>

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -11,6 +11,7 @@ class ErrorHandlingTest extends TestCase
         putenv('DB_CONFIG=' . $this->dbConfig);
         putenv('TESTING=1');
         putenv('DEBUG'); // ensure DEBUG is unset
+        $_SESSION['logged_in'] = true;
     }
 
     public function testDatabaseErrorHidesDetailsWhenDebugDisabled()


### PR DESCRIPTION
## Summary
- require active login session for all API endpoints
- extend test setup to initialize a logged-in session
- add tests verifying unauthorized requests return errors

## Testing
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6868abc3045c83248ee0c7df63aeca38