### PR TITLE
Add room count display

### DIFF
--- a/style.css
+++ b/style.css
@@ -1612,9 +1612,13 @@ button:focus {
   cursor: pointer;
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius);
- 
+
   color: var(--color-text);
   border: 1px solid transparent;
+}
+
+#summary .summary-room {
+  cursor: default;
 }
 
 #summary .summary-item[data-status="all"].active {


### PR DESCRIPTION
## Summary
- compute plant counts per room when loading plants
- show selected room's count in the summary header
- keep summary items interactive only for status filters
- style room summary entry so it isn't clickable

## Testing
- `npm test`
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6868ab5cd6748324907a3f48121ec96b