### PR TITLE
Add ET0 API tests

### DIFF
--- a/tests/Et0ApiTest.php
+++ b/tests/Et0ApiTest.php
@@ -1,0 +1,58 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class Et0ApiTest extends TestCase
+{
+    private $dbConfig;
+
+    protected function setUp(): void
+    {
+        $this->dbConfig = __DIR__ . '/db_stub.php';
+        putenv('DB_CONFIG=' . $this->dbConfig);
+        putenv('TESTING=1');
+    }
+
+    protected function tearDown(): void
+    {
+        if (isset($GLOBALS['mock_query_result'])) {
+            unset($GLOBALS['mock_query_result']);
+        }
+    }
+
+    public function testLogEt0InvalidParams()
+    {
+        $_POST = ['plant_id' => 0, 'et0_mm' => 1.2];
+        ob_start();
+        @include __DIR__ . '/../api/log_et0.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertArrayHasKey('error', $data);
+    }
+
+    public function testLogEt0ValidParams()
+    {
+        $_POST = ['plant_id' => 1, 'et0_mm' => 1.2, 'water_ml' => 30];
+        ob_start();
+        @include __DIR__ . '/../api/log_et0.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertEquals('ok', $data['status']);
+    }
+
+    public function testGetEt0Timeseries()
+    {
+        global $mock_query_result;
+        $mock_query_result = [
+            ['date' => '2023-01-01', 'et0_mm' => 1.1, 'water_ml' => 50],
+            ['date' => '2023-01-02', 'et0_mm' => 1.2, 'water_ml' => 60]
+        ];
+        $_GET = ['plant_id' => 1, 'days' => 2];
+        ob_start();
+        @include __DIR__ . '/../api/get_et0_timeseries.php';
+        $output = ob_get_clean();
+        $data = json_decode($output, true);
+        $this->assertCount(2, $data);
+        $this->assertEquals('2023-01-01', $data[0]['date']);
+    }
+}
+?>

--- a/tests/db_stub.php
+++ b/tests/db_stub.php
@@ -5,7 +5,20 @@ if (!class_exists('MockStmt')) {
         public function bind_result(&...$args) {}
         public function execute() { return true; }
         public function fetch() { return false; }
+        public function get_result() { return new MockResult(); }
         public function close() {}
+    }
+}
+
+if (!class_exists('MockResult')) {
+    class MockResult {
+        public function fetch_assoc() {
+            global $mock_query_result;
+            if (isset($mock_query_result) && count($mock_query_result) > 0) {
+                return array_shift($mock_query_result);
+            }
+            return null;
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- expand DB stub to handle query results
- add unit tests for log_et0.php and get_et0_timeseries.php

## Testing
- `phpunit`
- `npm test --silent` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6868b04ba5c88324a4769c27b53fdac5