### PR TITLE
Add equal height rows for plant grid

### DIFF
--- a/style.css
+++ b/style.css
@@ -882,6 +882,7 @@ button:focus {
 #plant-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-auto-rows: 1fr; /* ensure uniform card heights */
   gap: calc(var(--spacing) * 2);
 }
 
@@ -1087,6 +1088,7 @@ button:focus {
   padding: calc(var(--spacing) * 2);
   display: flex;
   flex-direction: column;
+  height: 100%;
   position: relative; /* allow urgency tag overlay */
   box-shadow: 0 1px 2px rgba(0,0,0,0.05);
   transition: box-shadow 0.2s, transform 0.2s;


### PR DESCRIPTION
## Summary
- enforce equal card heights with `grid-auto-rows` in `#plant-grid`
- allow each `.plant-card` to fill the row

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68693d084b0483249acff645261efcd0