### PR TITLE
Enable multi-room filtering

### DIFF
--- a/__tests__/chip.test.js
+++ b/__tests__/chip.test.js
@@ -5,7 +5,7 @@ function setupDOM() {
     <button id="filter-toggle"></button>
     <div id="filter-chips"></div>
     <span id="filter-summary"></span>
-    <select id="room-filter"><option value="all">All Rooms</option><option value="Kitchen">Kitchen</option></select>
+    <select id="room-filter" multiple><option value="Kitchen">Kitchen</option></select>
     <select id="status-filter"><option value="all" selected>All</option><option value="any">Needs Care</option></select>
     <select id="sort-toggle"><option value="due">Due Date</option><option value="name">Name</option></select>
     <div id="type-filters"><label>Succulent<input type="checkbox" value="succulent"></label></div>
@@ -31,7 +31,8 @@ test('updateFilterChips shows count and chips', async () => {
   expect(document.getElementById('filter-summary').textContent).toBe('No filters');
   expect(document.getElementById('filter-toggle').getAttribute('data-count')).toBe('0');
 
-  document.getElementById('room-filter').value = 'Kitchen';
+  const rf = document.getElementById('room-filter');
+  rf.querySelector('[value="Kitchen"]').selected = true;
   document.querySelector('#type-filters input').checked = true;
   mod.updateFilterChips();
   const chips = document.querySelectorAll('#filter-chips .filter-chip');
@@ -42,7 +43,7 @@ test('updateFilterChips shows count and chips', async () => {
 
 test('invalid saved values are ignored', async () => {
   setupDOM();
-  localStorage.setItem('roomFilter', 'Garage');
+  localStorage.setItem('roomFilter', JSON.stringify(['Garage']));
   localStorage.setItem('sortPref', 'bogus');
   localStorage.setItem('statusFilter', 'bad');
   let mod;
@@ -52,7 +53,7 @@ test('invalid saved values are ignored', async () => {
   const roomEl = document.getElementById('room-filter');
   const sortEl = document.getElementById('sort-toggle');
   const statusEl = document.getElementById('status-filter');
-  expect(roomEl.value).toBe('all');
+  expect(roomEl.selectedOptions.length).toBe(0);
   expect(sortEl.value).toBe('due');
   expect(statusEl.value).toBe('all');
 

--- a/__tests__/fab.test.js
+++ b/__tests__/fab.test.js
@@ -15,7 +15,7 @@ test('clicking show-add-form reveals form', async () => {
     <button id="undo-btn"></button>
     <button id="cancel-edit"></button>
     <div id="plant-grid"></div>
-    <select id="room-filter"><option value="all">All</option></select>
+    <select id="room-filter" multiple></select>
     <input id="search-input" value="" />
     <select id="sort-toggle"><option value="due">Due</option></select>
   `;

--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -3,7 +3,7 @@ import { jest } from '@jest/globals';
 function setupDOM() {
   document.body.innerHTML = `
     <div id="plant-grid"></div>
-    <select id="room-filter"><option value="all">All</option><option value="Kitchen">Kitchen</option><option value="Patio">Patio</option></select>
+    <select id="room-filter" multiple><option value="Kitchen">Kitchen</option><option value="Patio">Patio</option></select>
     <select id="status-filter"><option value="all" selected>All</option><option value="water">Watering</option><option value="any">Needs Care</option></select>
     <input id="search-input" value="" />
     <header id="summary">
@@ -57,7 +57,8 @@ test('loadPlants filters by room and search query', async () => {
   await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
 
   document.getElementById('search-input').value = 'aloe';
-  document.getElementById('room-filter').value = 'Kitchen';
+  const rf = document.getElementById('room-filter');
+  rf.querySelector('[value="Kitchen"]').selected = true;
   await mod.loadPlants();
 
   const cards = document.querySelectorAll('.plant-card-wrapper');
@@ -207,7 +208,8 @@ test('needs care alert count ignores room filter', async () => {
   let mod;
   await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
 
-  document.getElementById('room-filter').value = 'Patio';
+  const rf = document.getElementById('room-filter');
+  rf.querySelector('[value="Patio"]').selected = true;
   await mod.loadPlants();
   const badge = document.getElementById('needs-care-alert');
   expect(badge.textContent).toBe('1');
@@ -277,13 +279,14 @@ test('clear filters button resets values and recounts', async () => {
   await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
   document.dispatchEvent(new Event('DOMContentLoaded'));
 
-  document.getElementById('room-filter').value = 'Kitchen';
+  const rf = document.getElementById('room-filter');
+  rf.querySelector('[value="Kitchen"]').selected = true;
   await mod.loadPlants();
   expect(document.querySelectorAll('.plant-card-wrapper').length).toBe(1);
 
   document.getElementById('clear-filters').click();
 
-  expect(document.getElementById('room-filter').value).toBe('all');
+  expect(document.getElementById('room-filter').selectedOptions.length).toBe(0);
   expect(document.getElementById('status-filter').value).toBe('all');
 
   await mod.loadPlants();
@@ -307,7 +310,8 @@ test('room summary shows due count', async () => {
   });
   let mod;
   await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
-  document.getElementById('room-filter').value = 'Kitchen';
+  const rf = document.getElementById('room-filter');
+  rf.querySelector('[value="Kitchen"]').selected = true;
   await mod.loadPlants();
   const roomItem = document.querySelector('#room-summary .summary-room');
   expect(roomItem.textContent).toBe('2 in Kitchen \u2014 2 need care');

--- a/__tests__/focus.test.js
+++ b/__tests__/focus.test.js
@@ -21,7 +21,7 @@ test('clear hash resets focusPlantId and prevents URL updates', async () => {
   window.location.hash = '#plant-5';
   document.body.innerHTML = `
     <div id="plant-grid"></div>
-    <select id="room-filter"><option value="all">All</option></select>
+    <select id="room-filter" multiple></select>
     <input id="search-input" value="" />
     <header id="summary">
       <div id="summary-counts"></div>

--- a/__tests__/network.test.js
+++ b/__tests__/network.test.js
@@ -4,7 +4,7 @@ function setupDOM() {
   document.body.innerHTML = `
     <div id="toast"></div>
     <div id="plant-grid"></div>
-    <select id="room-filter"><option value="all">All</option></select>
+    <select id="room-filter" multiple></select>
     <select id="status-filter"><option value="all" selected>All</option></select>
     <input id="search-input" value="" />
     <header id="summary">

--- a/index.html
+++ b/index.html
@@ -162,8 +162,8 @@
         </select>
         <div class="overflow-container relative">
             <div id="filter-panel" class="overflow-menu" role="menu" aria-hidden="true">
-                <select id="room-filter" class="border rounded-md">
-                    <option value="all" selected>All Rooms</option>
+                <select id="room-filter" class="border rounded-md" multiple>
+                    <!-- rooms inserted dynamically -->
                 </select>
                 <select id="status-filter" class="border rounded-md hidden">
                     <option value="all" selected>Status: All</option>


### PR DESCRIPTION
## Summary
- allow selecting multiple rooms in filter panel
- persist each selected room in preferences
- update filtering logic for multiple rooms
- update archived link and summary behaviors for multi-room selections
- adjust tests for new multi-room filter behavior

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68695fd843b8832486075680159645a1