### PR TITLE
Add multi-selection hint and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The toolbar includes a **Filters** button on smaller screens. Clicking it reveal
 dropdowns for narrowing the list. You can filter by **room**, show plants that
 need specific **care** (watering or fertilizing), and change the **sort** order.
 Selections apply instantly and the panel hides after you choose an option.
+You can select multiple rooms by holding Ctrl/Cmd or Shift while clicking.
 
 The search box in the toolbar now stays visible while you scroll so you can
 quickly look up plants at any time.

--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -318,3 +318,25 @@ test('room summary shows due count', async () => {
   jest.useRealTimers();
 });
 
+
+
+test('loadPlants handles multiple room selection', async () => {
+  setupDOM();
+  const plants = [
+    { id: 1, name: 'A', species: 'sp', room: 'Kitchen', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' },
+    { id: 2, name: 'B', species: 'sp', room: 'Patio', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' }
+  ];
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(plants)
+  });
+  let mod;
+  await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
+  const rf = document.getElementById('room-filter');
+  rf.querySelector('[value="Kitchen"]').selected = true;
+  rf.querySelector('[value="Patio"]').selected = true;
+  await mod.loadPlants();
+  const cards = document.querySelectorAll('.plant-card-wrapper');
+  expect(cards.length).toBe(2);
+});

--- a/index.html
+++ b/index.html
@@ -162,7 +162,7 @@
         </select>
         <div class="overflow-container relative">
             <div id="filter-panel" class="overflow-menu" role="menu" aria-hidden="true">
-                <select id="room-filter" class="border rounded-md" multiple>
+                <select id="room-filter" class="border rounded-md" multiple title="Hold Ctrl/Cmd or Shift to select multiple rooms">
                     <!-- rooms inserted dynamically -->
                 </select>
                 <select id="status-filter" class="border rounded-md hidden">


### PR DESCRIPTION
## Summary
- document how to multi-select rooms in README
- hint users in room filter select
- test multi-select rooms in filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869675c13a48324a4f98635145e8b5e