### PR TITLE
Improve mobile summary layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -1766,23 +1766,21 @@ button:focus {
 
 @media (max-width: 640px) {
   #summary {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-  #summary-counts {
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-template-areas:
-      "plants plants"
+      "plants weather"
       "water fert";
     align-items: flex-start;
+    row-gap: var(--spacing);
   }
+  #summary-counts { display: contents; }
+  #summary-info { display: contents; }
   #summary-counts .summary-plants { grid-area: plants; }
-  #summary-counts .summary-water { grid-area: water; }
-  #summary-counts .summary-fert { grid-area: fert; }
-  #summary-date {
-    margin-left: 0;
-  }
+  #summary-counts .summary-water  { grid-area: water; }
+  #summary-counts .summary-fert   { grid-area: fert; }
+  #summary-weather { grid-area: weather; }
+  #summary-date { display: none; }
 }
 
 


### PR DESCRIPTION
## Summary
- adjust mobile layout for summary header
  - switch to grid layout and hide the date on small screens

## Testing
- `npm test` *(fails: jest module missing)*
- `phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68696530c2dc8324a32e5ffa11c36e82