### PR TITLE
Fix header spacing from weather icon

### DIFF
--- a/style.css
+++ b/style.css
@@ -1765,6 +1765,10 @@ button:focus {
   margin-right: 0.25em;
 }
 
+#summary-weather {
+  line-height: 1;
+}
+
 @media (max-width: 640px) {
   #summary {
     display: grid;


### PR DESCRIPTION
## Summary
- keep header compact by overriding line-height for the weather element

## Testing
- `npm test`
- `phpunit --configuration phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_6869927c305483249e624608b89840ac