### PR TITLE
Enable calendar jump from date summary

### DIFF
--- a/__tests__/date_to_calendar.test.js
+++ b/__tests__/date_to_calendar.test.js
@@ -1,0 +1,45 @@
+import { jest } from '@jest/globals';
+
+beforeEach(() => {
+  jest.resetModules();
+  Object.defineProperty(document, 'readyState', {
+    configurable: true,
+    get: () => 'loading'
+  });
+});
+
+test('summary date scrolls to calendar', async () => {
+  document.body.innerHTML = `
+    <div id="toast"></div>
+    <div id="plant-grid"></div>
+    <select id="room-filter" multiple></select>
+    <input id="search-input" value="" />
+    <header id="summary">
+      <button id="show-add-form"></button>
+      <div id="summary-counts"></div>
+      <div id="summary-date"></div>
+      <div id="summary-weather"></div>
+    </header>
+    <select id="sort-toggle"></select>
+    <form id="plant-form"></form>
+    <button id="undo-btn"></button>
+    <button id="cancel-edit"></button>
+    <div id="calendar-heading"></div>
+  `;
+
+  HTMLElement.prototype.scrollIntoView = jest.fn();
+
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve([])
+  });
+
+  await jest.isolateModulesAsync(async () => { await import('../script.js'); });
+  document.dispatchEvent(new Event('DOMContentLoaded'));
+
+  const dateEl = document.getElementById('summary-date');
+  dateEl.click();
+
+  expect(HTMLElement.prototype.scrollIntoView).toHaveBeenCalled();
+});

--- a/script.js
+++ b/script.js
@@ -2096,6 +2096,7 @@ async function init(){
 
   const calendarEl = document.getElementById('calendar');
   const calendarHeading = document.getElementById('calendar-heading');
+  const summaryDate = document.getElementById('summary-date');
 
   const photoDrop = document.getElementById('photo-drop');
   const photoInput = document.getElementById('photo');
@@ -2138,6 +2139,20 @@ async function init(){
   applyViewMode();
   updateFilterChips();
   updateSegments(0, 0, 0);
+
+  if (summaryDate && calendarHeading) {
+    summaryDate.setAttribute('role', 'button');
+    summaryDate.tabIndex = 0;
+    summaryDate.addEventListener('click', () => {
+      calendarHeading.scrollIntoView({ behavior: 'smooth' });
+    });
+    summaryDate.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        summaryDate.click();
+      }
+    });
+  }
 
   segButtons.forEach(btn => {
     btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- make summary date element scroll smoothly to the calendar
- test that clicking the date triggers scrolling

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68699a9a626483248d234c3592e05d0d