### PR TITLE
Fix mobile view - hide date

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         <button id="show-add-form"><span class="visually-hidden">Add Plant</span></button>
         <div id="summary-counts"></div>
         <div id="summary-info" class="summary-row">
-            <div id="summary-date"></div>
+            <div id="summary-date" class="hidden sm:block"></div>
             <div id="summary-weather"></div>
         </div>
     </header>


### PR DESCRIPTION
## Summary
- hide summary date in mobile view with `hidden sm:block`

## Testing
- `npm test`
- `phpunit --log-junit /tmp/phpunit.log`

------
https://chatgpt.com/codex/tasks/task_e_68699dfc721083249a949d5d0b1e8f29