### PR TITLE
Show counts for filters

### DIFF
--- a/__tests__/filter.test.js
+++ b/__tests__/filter.test.js
@@ -340,3 +340,24 @@ test('loadPlants handles multiple room selection', async () => {
   const cards = document.querySelectorAll('.plant-card-wrapper');
   expect(cards.length).toBe(2);
 });
+
+test('type filter labels include counts', async () => {
+  setupDOM();
+  const plants = [
+    { id: 1, name: 'A', species: 'sp', room: 'Kitchen', plant_type: 'succulent', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' },
+    { id: 2, name: 'B', species: 'sp', room: 'Kitchen', plant_type: 'herb', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' },
+    { id: 3, name: 'C', species: 'sp', room: 'Patio', plant_type: 'succulent', watering_frequency: 7, fertilizing_frequency: 0, last_watered: '2023-01-01', last_fertilized: null, created_at: '2023-01-01' }
+  ];
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(plants)
+  });
+  let mod;
+  await jest.isolateModulesAsync(async () => { mod = await import('../script.js'); });
+  await mod.loadPlants();
+  const succLabel = document.querySelectorAll('#type-filters label')[1];
+  const herbLabel = document.querySelectorAll('#type-filters label')[2];
+  expect(succLabel.textContent).toContain('Succulent (2)');
+  expect(herbLabel.textContent).toContain('Herb (1)');
+});

--- a/script.js
+++ b/script.js
@@ -663,6 +663,28 @@ function updateSegments(total, water, fert) {
   });
 }
 
+function updateTypeFilterCounts(counts) {
+  const containers = document.querySelectorAll('#type-filters');
+  containers.forEach(container => {
+    container.querySelectorAll('input').forEach(cb => {
+      const label = cb.closest('label');
+      if (!label) return;
+      if (!label.dataset.baseLabel) {
+        const text = label.textContent.trim();
+        label.dataset.baseLabel = text.replace(/\s*\(\d+\)$/, '');
+      }
+      const base = label.dataset.baseLabel;
+      const count = counts[cb.value] || 0;
+      let textNode = Array.from(label.childNodes).find(n => n.nodeType === Node.TEXT_NODE);
+      if (!textNode) {
+        textNode = document.createTextNode('');
+        label.appendChild(textNode);
+      }
+      textNode.textContent = `${base} (${count})`;
+    });
+  });
+}
+
 
 
 
@@ -1479,6 +1501,13 @@ async function loadPlants() {
   });
   filterCounts.needsCare = needsCareCount;
 
+  const typeCounts = {};
+  plants.forEach(plant => {
+    const ptype = plant.plant_type || 'houseplant';
+    typeCounts[ptype] = (typeCounts[ptype] || 0) + 1;
+  });
+  updateTypeFilterCounts(typeCounts);
+
   const filtered = plants.filter(plant => {
     if (selectedRooms.length && !selectedRooms.includes(plant.room)) return false;
     const haystack = (plant.name + ' ' + plant.species).toLowerCase();
@@ -2011,7 +2040,8 @@ async function loadPlants() {
     rooms.forEach(r => {
       const opt = document.createElement('option');
       opt.value = r;
-      opt.textContent = r;
+      const count = roomCounts[r] || 0;
+      opt.textContent = `${r} (${count})`;
       if (current.includes(r)) opt.selected = true;
       filter.appendChild(opt);
     });


### PR DESCRIPTION
## Summary
- compute counts for each plant type
- display counts in room and type filter labels
- test that filter labels show totals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68699d4d059c83248b1c4aca0a4e09b4