### PR TITLE
Keep filter panel open for multi-select

### DIFF
--- a/script.js
+++ b/script.js
@@ -2477,7 +2477,7 @@ async function init(){
       await loadPlants();
       checkArchivedLink();
       updateFilterChips();
-      if (filterPanel) {
+      if (filterPanel && !roomFilter.hasAttribute('multiple')) {
         filterPanel.classList.remove('show');
         filterToggle.setAttribute('aria-expanded', 'false');
         filterPanel.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
## Summary
- stop auto-closing the filter panel when the room selector supports multiple options

## Testing
- `npm test`
- `phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68699f2401ec8324b2dbb37d24936296