### PR TITLE
Fix summary date responsive visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
         <button id="show-add-form"><span class="visually-hidden">Add Plant</span></button>
         <div id="summary-counts"></div>
         <div id="summary-info" class="summary-row">
-            <div id="summary-date" class="hidden sm:block"></div>
+            <div id="summary-date" class="summary-item hidden sm:flex"></div>
             <div id="summary-weather"></div>
         </div>
     </header>

--- a/script.js
+++ b/script.js
@@ -1593,9 +1593,6 @@ async function loadPlants() {
   });
 
   if (dateContainer) {
-    if (window.innerWidth >= 640) {
-      dateContainer.classList.add('summary-item');
-    }
     dateContainer.innerHTML = `${ICONS.calendar} ${todayStr}`;
   }
 


### PR DESCRIPTION
## Summary
- adjust summary date classes so it stays hidden on mobile
- simplify script handling of summary date

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869a30f947c83248b6735e2cf8a0e9d